### PR TITLE
Apply Hardened armor rules during physical defense test

### DIFF
--- a/public/locale/en/config.json
+++ b/public/locale/en/config.json
@@ -1019,6 +1019,7 @@
     "SR5.Test": "Test",
     "SR5.TestResults": {
         "AttackBlockedByVehicleArmor": "Attack Hits But Is Blocked By Vehicle Armor",
+        "AttackBlockedByHardenedArmor": "Attack Hits But Is Blocked By Hardened Armor",
         "AttackDodged": "Attack Dodged",
         "AttackDoesNoPhysicalDamageToVehicle": "Attack Hits But Does No Physical Damage To Vehicle",
         "AttackHits": "Attack Hits",

--- a/public/locale/en/config.json
+++ b/public/locale/en/config.json
@@ -1018,8 +1018,8 @@
     "SR5.TemporaryModifiers": "Temporary Modifiers",
     "SR5.Test": "Test",
     "SR5.TestResults": {
-        "AttackBlockedByVehicleArmor": "Attack Hits But Is Blocked By Vehicle Armor",
         "AttackBlockedByHardenedArmor": "Attack Hits But Is Blocked By Hardened Armor",
+        "AttackBlockedByVehicleArmor": "Attack Hits But Is Blocked By Vehicle Armor",
         "AttackDodged": "Attack Dodged",
         "AttackDoesNoPhysicalDamageToVehicle": "Attack Hits But Does No Physical Damage To Vehicle",
         "AttackHits": "Attack Hits",

--- a/src/module/actor/SR5Actor.ts
+++ b/src/module/actor/SR5Actor.ts
@@ -153,7 +153,7 @@ export class SR5Actor extends Actor {
      * @override
      */
     override applyActiveEffects() {
-        // Shadowrun uses prepareDerivedData to calculate lot's of things that don't exist on the data model in full.
+        // Shadowrun uses prepareDerivedData to calculate lots of things that don't exist on the data model in full.
         // Errors during change application will stop that process and cause a broken sheet.
         try {
             super.applyActiveEffects();

--- a/src/module/rules/CombatRules.ts
+++ b/src/module/rules/CombatRules.ts
@@ -133,6 +133,35 @@ export class CombatRules {
             return false;
         }
 
+        return CombatRules.isDamageLessThanArmor(incomingDamage, attackerHits, defenderHits, actor);
+    }
+
+    /**
+     * Check if actor wouldn't take any damage due to hardened armor rules (SR5#397)
+     * @param incomingDamage The incoming damage
+     * @param attackerHits The attackers hits. Should be a positive number.
+     * @param defenderHits The attackers hits. Should be a positive number.
+     * @param actor The active defender
+     */
+    static isBlockedByHardenedArmor(incomingDamage: DamageData, attackerHits: number, defenderHits: number, actor: SR5Actor): boolean {
+        const armor = actor.getArmor(incomingDamage);
+
+        if(!armor.hardened) {
+            return false;
+        }
+
+        return CombatRules.isDamageLessThanArmor(incomingDamage, attackerHits, defenderHits, actor);
+    }
+
+    /**
+     * Check if incoming damage (modified by net hits) is less than the actor's armor (modified by AP).
+     * Used for vehicle armor, hardened armor, and physical -> stun damage logic
+     * @param incomingDamage The incoming damage
+     * @param attackerHits The attackers hits. Should be a positive number.
+     * @param defenderHits The attackers hits. Should be a positive number.
+     * @param actor The active defender
+     */
+    static isDamageLessThanArmor(incomingDamage: DamageData, attackerHits: number, defenderHits: number, actor: SR5Actor): boolean {
         const modifiedDamage = CombatRules.modifyDamageAfterHit(actor, attackerHits, defenderHits, incomingDamage);
 
         const modifiedAv = actor.getArmor(incomingDamage).value;

--- a/src/module/tests/PhysicalDefenseTest.ts
+++ b/src/module/tests/PhysicalDefenseTest.ts
@@ -192,6 +192,10 @@ export class PhysicalDefenseTest extends DefenseTest {
             test: () => this.actor !== undefined && CombatRules.isBlockedByVehicleArmor(this.data.incomingDamage, this.against.hits.value, this.hits.value, this.actor),
             label: "SR5.TestResults.AttackBlockedByVehicleArmor",
         },
+        {
+            test: () => this.actor !== undefined && CombatRules.isBlockedByHardenedArmor(this.data.incomingDamage, this.against.hits.value, this.hits.value, this.actor),
+            label: "SR5.TestResults.AttackBlockedByHardenedArmor",
+        }
     ];
 
     private getNoDamageCondition(): PhysicalDefenseNoDamageCondition|undefined {

--- a/src/unittests/sr5.AttackTests.spec.ts
+++ b/src/unittests/sr5.AttackTests.spec.ts
@@ -6,6 +6,9 @@ import { SR5Actor } from '../module/actor/SR5Actor';
 import { SR5Item } from '../module/item/SR5Item';
 import { DataDefaults } from '../module/data/DataDefaults';
 import { CombatRules } from '../module/rules/CombatRules';
+import DamageType = Shadowrun.DamageType;
+import DamageElement = Shadowrun.DamageElement;
+import DamageData = Shadowrun.DamageData;
 
 export const shadowrunAttackTesting = (context: QuenchBatchContext) => {
     const {describe, it, assert, before, after} = context;
@@ -167,25 +170,80 @@ export const shadowrunAttackTesting = (context: QuenchBatchContext) => {
             testScene = new SR5TestingDocuments(Scene);
         });
 
+        const getCharacterWithArmor = async (armorValue: number, {
+            hardened = false
+        }: {
+            hardened?: boolean
+        } = {}): Promise<SR5Actor> => {
+            const characterActor = await testActor.create({
+                type: 'character',
+            }) as SR5Actor;
+            const armor = await testItem.create({
+                type: 'armor',
+                name: 'Test Armor',
+                system: {
+                    armor: {
+                        base: armorValue,
+                        value: armorValue,
+                        hardened,
+                        mod: null, // Without this, the system defaults to an empty array for mod and thinks this is an armor accessory, therefore not applying hardened armor rules
+                    },
+                    technology: DataDefaults.technologyData({
+                        equipped: true,
+                    })
+                }
+            });
+            await characterActor.createEmbeddedDocuments('Item',  [armor]);
+            return characterActor;
+        }
+
+        const getVehicleWithArmor = async (armorValue: number): Promise<SR5Actor> => {
+            const armor = DataDefaults.actorArmor({
+                value: armorValue,
+                base: armorValue,
+            });
+            return await testActor.create({
+                type: 'vehicle', system: {
+                    armor,
+                },
+            }) as SR5Actor;
+        }
+
+        const getDamage = (damageValue: number, {
+            type = "physical",
+            ap = 0,
+            element,
+        }: {
+            type?: DamageType,
+            ap?: number,
+            element?: DamageElement
+        } = {}): DamageData => {
+            return DataDefaults.damageData({
+                type: {
+                    value: type,
+                    base: type,
+                },
+                value: damageValue,
+                base: damageValue,
+                ...(ap && {
+                    ap: {
+                        base: ap,
+                        value: ap,
+                    }
+                }),
+                ...(element && {
+                    element: {
+                        base: element,
+                        value: element,
+                    }
+                }),
+            });
+        }
+
         describe("isBlockedByVehicleArmor", () => {
             it('blocks damage due to vehicle armor', async () => {
-                const armor = DataDefaults.actorArmor({
-                    value: 50,
-                    base: 50,
-                });
-                const vehicle = await testActor.create({
-                    type: 'vehicle', system: {
-                        armor,
-                    },
-                }) as SR5Actor;
-                const damage = DataDefaults.damageData({
-                    type: {
-                        value: 'physical',
-                        base: 'physical',
-                    },
-                    value: 4,
-                    base: 4,
-                });
+                const vehicle = await getVehicleWithArmor(50);
+                const damage = getDamage(4);
 
                 const result = CombatRules.isBlockedByVehicleArmor(damage, 5, 2, vehicle);
 
@@ -193,41 +251,9 @@ export const shadowrunAttackTesting = (context: QuenchBatchContext) => {
             });
 
             it("doesn't block damage for non-vehicle actors", async () => {
-                const vehicleArmor = DataDefaults.actorArmor({
-                    value: 50,
-                    base: 50,
-                });
-                const vehicleActor = await testActor.create({
-                    type: 'vehicle', system: {
-                        armor: vehicleArmor,
-                    },
-                }) as SR5Actor;
-
-                const characterActor = await testActor.create({
-                    type: 'character',
-                }) as SR5Actor;
-                await characterActor.createEmbeddedDocuments('Item',  [{
-                    type: 'armor',
-                    name: 'Test Armor',
-                    system: {
-                        armor: {
-                            base: 50,
-                            value: 50,
-                        },
-                        technology: DataDefaults.technologyData({
-                            equipped: true,
-                        })
-                    }
-                }]);
-
-                const damage = DataDefaults.damageData({
-                    type: {
-                        value: 'physical',
-                        base: 'physical',
-                    },
-                    value: 4,
-                    base: 4,
-                });
+                const vehicleActor = await getVehicleWithArmor(50);
+                const characterActor = await getCharacterWithArmor(50);
+                const damage = getDamage(4);
 
                 const characterResult = CombatRules.isBlockedByVehicleArmor(damage, 5, 2, characterActor);
                 const vehicleResult = CombatRules.isBlockedByVehicleArmor(damage, 5, 2, vehicleActor);
@@ -237,23 +263,8 @@ export const shadowrunAttackTesting = (context: QuenchBatchContext) => {
             });
 
             it("takes net hits into account", async () => {
-                const armor = DataDefaults.actorArmor({
-                    value: 6,
-                    base: 6,
-                });
-                const vehicle = await testActor.create({
-                    type: 'vehicle', system: {
-                        armor,
-                    },
-                }) as SR5Actor;
-                const damage = DataDefaults.damageData({
-                    type: {
-                        value: 'physical',
-                        base: 'physical',
-                    },
-                    value: 4,
-                    base: 4,
-                });
+                const vehicle = await getVehicleWithArmor(6);
+                const damage = getDamage(4);
 
                 const blockedResult = CombatRules.isBlockedByVehicleArmor(damage, 5, 4, vehicle);
                 const notBlockedResult = CombatRules.isBlockedByVehicleArmor(damage, 5, 3, vehicle);
@@ -263,40 +274,10 @@ export const shadowrunAttackTesting = (context: QuenchBatchContext) => {
             });
 
             it("takes AP into account", async () => {
-                const armor = DataDefaults.actorArmor({
-                    value: 6,
-                    base: 6,
-                });
-                const vehicle = await testActor.create({
-                    type: 'vehicle', system: {
-                        armor,
-                    },
-                }) as SR5Actor;
+                const vehicle = await getVehicleWithArmor(6);
                 // This is "high" AP but a negative number, just go with it
-                const highApDamage = DataDefaults.damageData({
-                    type: {
-                        value: 'physical',
-                        base: 'physical',
-                    },
-                    value: 4,
-                    base: 4,
-                    ap: {
-                        base: -5,
-                        value: -5,
-                    }
-                });
-                const lowApDamage = DataDefaults.damageData({
-                    type: {
-                        value: 'physical',
-                        base: 'physical',
-                    },
-                    value: 4,
-                    base: 4,
-                    ap: {
-                        base: 5,
-                        value: 5,
-                    }
-                });
+                const highApDamage = getDamage(4, { ap: -5 });
+                const lowApDamage = getDamage(4, { ap: 5 });
 
                 const blockedResult = CombatRules.isBlockedByVehicleArmor(lowApDamage, 5, 3, vehicle);
                 const notBlockedResult = CombatRules.isBlockedByVehicleArmor(highApDamage, 5, 3, vehicle);
@@ -306,17 +287,57 @@ export const shadowrunAttackTesting = (context: QuenchBatchContext) => {
             });
         });
 
+        describe("isBlockedByHardenedArmor", () => {
+            it('blocks damage due to hardened armor', async () => {
+                const vehicle = await getCharacterWithArmor(50, { hardened: true });
+                const damage = getDamage(4);
+
+                const result = CombatRules.isBlockedByHardenedArmor(damage, 5, 2, vehicle);
+
+                assert.isTrue(result);
+            });
+
+            it("doesn't block damage for non-vehicle actors", async () => {
+                const hardenedArmorActor = await getCharacterWithArmor(50, { hardened: true });
+                const normalArmorActor = await getCharacterWithArmor(50);
+                const damage = getDamage(4);
+
+                const characterResult = CombatRules.isBlockedByHardenedArmor(damage, 5, 2, normalArmorActor);
+                const vehicleResult = CombatRules.isBlockedByHardenedArmor(damage, 5, 2, hardenedArmorActor);
+
+                assert.isFalse(characterResult);
+                assert.isTrue(vehicleResult);
+            });
+
+            it("takes net hits into account", async () => {
+                const actor = await getCharacterWithArmor(6, { hardened: true });
+                const damage = getDamage(4);
+
+                const blockedResult = CombatRules.isBlockedByHardenedArmor(damage, 5, 4, actor);
+                const notBlockedResult = CombatRules.isBlockedByHardenedArmor(damage, 5, 3, actor);
+
+                assert.isTrue(blockedResult);
+                assert.isFalse(notBlockedResult);
+            });
+
+            it("takes AP into account", async () => {
+                const actor = await getCharacterWithArmor(6, { hardened: true });
+                // This is "high" AP but a negative number, just go with it
+                const highApDamage = getDamage(4, { ap: -5 });
+                const lowApDamage = getDamage(4, { ap: 5 });
+
+                const blockedResult = CombatRules.isBlockedByHardenedArmor(lowApDamage, 5, 3, actor);
+                const notBlockedResult = CombatRules.isBlockedByHardenedArmor(highApDamage, 5, 3, actor);
+
+                assert.isTrue(blockedResult);
+                assert.isFalse(notBlockedResult);
+            });
+        });
+
         describe("doesNoPhysicalDamageToVehicle", () => {
             it("blocks non-physical damage to vehicle", async () => {
                 const vehicle = await testActor.create({ type: 'vehicle' }) as SR5Actor;
-                const damage = DataDefaults.damageData({
-                    type: {
-                        value: 'stun',
-                        base: 'stun',
-                    },
-                    value: 4,
-                    base: 4,
-                });
+                const damage = getDamage(4, { type: 'stun' });
 
                 const result = CombatRules.doesNoPhysicalDamageToVehicle(damage, vehicle);
 
@@ -325,14 +346,7 @@ export const shadowrunAttackTesting = (context: QuenchBatchContext) => {
 
             it("does not block physical damage to vehicle", async () => {
                 const vehicle = await testActor.create({ type: 'vehicle' }) as SR5Actor;
-                const damage = DataDefaults.damageData({
-                    type: {
-                        value: 'physical',
-                        base: 'physical',
-                    },
-                    value: 4,
-                    base: 4,
-                });
+                const damage = getDamage(4, { type: 'physical' });
 
                 const result = CombatRules.doesNoPhysicalDamageToVehicle(damage, vehicle);
 
@@ -341,18 +355,7 @@ export const shadowrunAttackTesting = (context: QuenchBatchContext) => {
 
             it("does not block electric stun damage to vehicle", async () => {
                 const vehicle = await testActor.create({ type: 'vehicle' }) as SR5Actor;
-                const damage = DataDefaults.damageData({
-                    type: {
-                        value: 'stun',
-                        base: 'stun',
-                    },
-                    element: {
-                        base: 'electricity',
-                        value: 'electricity',
-                    },
-                    value: 4,
-                    base: 4,
-                });
+                const damage = getDamage(4, { type: 'stun', element: 'electricity' });
 
                 const result = CombatRules.doesNoPhysicalDamageToVehicle(damage, vehicle);
 

--- a/src/unittests/sr5.AttackTests.spec.ts
+++ b/src/unittests/sr5.AttackTests.spec.ts
@@ -170,6 +170,12 @@ export const shadowrunAttackTesting = (context: QuenchBatchContext) => {
             testScene = new SR5TestingDocuments(Scene);
         });
 
+        after(async () => {
+            await testActor.teardown();
+            await testItem.teardown();
+            await testScene.teardown();
+        })
+
         const getCharacterWithArmor = async (armorValue: number, {
             hardened = false
         }: {


### PR DESCRIPTION
Similar to vehicle armor, this changeset applies the rules for hardened armor during the physical defense test such that if `modified DV < modified AV`, the attack automatically does no damage.