### PR TITLE
[BUG] Re-implement saving of scroll position on document update

### DIFF
--- a/src/css/bundle.scss
+++ b/src/css/bundle.scss
@@ -197,6 +197,7 @@ input[type='checkbox'].toggle {
     max-height: 0;
     overflow-y: auto;
     transition: max-height 0.25s ease-in-out;
+    color: $white;
 }
 
 .toggle:checked + .list-item-content + .collapsible-content {
@@ -558,7 +559,7 @@ input[type='text'].display {
     }
 
     label.item-text.item-name[for="select-inventory"] {
-        color: $edge;
+        color: $yellow;
     }
 
     label.item-text.item-name {
@@ -1175,7 +1176,7 @@ input[type='text'].display {
 
 
 .list-header.item-section[data-item-id="weapon"][data-item-type=""] {
-    color: $edge;  /* set the color to yellow */
+    color: $yellow;  /* set the color to yellow */
     font-size: small;
 }
 

--- a/src/css/config/_mixins.scss
+++ b/src/css/config/_mixins.scss
@@ -45,4 +45,5 @@
 
 @mixin linkHovered {
     text-shadow: 0 0 8px var(--color-shadow-primary);
+    color: $fLightRed;
 }

--- a/src/templates/actor/parts/matrix/ProgramList.html
+++ b/src/templates/actor/parts/matrix/ProgramList.html
@@ -1,4 +1,4 @@
-<div class="scroll-area-matrix">
+<div class="scroll-area scroll-area-matrix">
     {{> 'systems/shadowrun5e/dist/templates/common/List/ListHeader.html'
             name=(localize 'SR5.Programs')
             itemId='program'

--- a/src/templates/actor/tabs/InventoryTab.html
+++ b/src/templates/actor/tabs/InventoryTab.html
@@ -43,7 +43,7 @@
                 </div>
             </div>
         </div>
-        <div class="scroll-area-inventory">
+        <div class="scroll-area scroll-area-inventory">
             {{#each inventory.types as |section type|}}
                 <div class="custom-section-heading">
                     {{> 'systems/shadowrun5e/dist/templates/common/List/ListHeader.html'

--- a/src/templates/actor/tabs/MiscTab.html
+++ b/src/templates/actor/tabs/MiscTab.html
@@ -245,7 +245,7 @@
                 </div>
             </div>
             <div class="flexcol">
-                <div class="scroll-area-mods">
+                <div class="scroll-area scroll-area-mods">
                     <!-- Situational Modifiers Section -->
                     {{#if situationModifiers}}
                     <div class="list-item item-section wrap-collapsible">


### PR DESCRIPTION
will move the new css classes scroll-area-skills etc to scroll-area so the update function remembers the last scroll position. Hover improvements on item and header hover