### PR TITLE
[BUG] RangedAttackTest did filter actor uuids using token uuids

### DIFF
--- a/src/module/tests/RangedAttackTest.ts
+++ b/src/module/tests/RangedAttackTest.ts
@@ -127,12 +127,12 @@ export class RangedAttackTest extends SuccessTest {
         }
 
         // Build target ranges for template display.
-        this.data.targetRanges = this.targets.map(target => {
-            const distance = Helpers.measureTokenDistance(attacker, target);
+        this.data.targetRanges = this.targets.map(token => {
+            const distance = Helpers.measureTokenDistance(attacker, token);
             const range = RangedWeaponRules.getRangeForTargetDistance(distance, this.data.ranges);
             return {
-                uuid: target.uuid,
-                name: target.name || '',
+                tokenUuid: token.uuid,
+                name: token.name || '',
                 unit: LENGTH_UNIT,
                 range,
                 distance,
@@ -240,7 +240,11 @@ export class RangedAttackTest extends SuccessTest {
             const target = this.data.targetRanges[this.data.targetRangesSelected];
             this.data.range = target.range.modifier;
 
-            this.data.targetActorsUuid = this.data.targetActorsUuid.filter(uuid => uuid === target.uuid);
+            // Reduce all targets selected down to the actual target fired upon.
+            const token = fromUuidSync(target.tokenUuid) as TokenDocument;
+            if (!(token instanceof TokenDocument)) return console.error(`Shadowrun 5e | ${this.type} got a target that is no TokenDocument`, token);
+            if (!token.actor) return console.error(`Shadowrun 5e | ${this.type} got a token that has no actor`, token);
+            this.data.targetActorsUuid = this.data.targetActorsUuid.filter(uuid => uuid === token.actor?.uuid);
         }
 
         // Alter test data for range.

--- a/src/module/tests/RangedAttackTest.ts
+++ b/src/module/tests/RangedAttackTest.ts
@@ -244,7 +244,8 @@ export class RangedAttackTest extends SuccessTest {
             const token = fromUuidSync(target.tokenUuid) as TokenDocument;
             if (!(token instanceof TokenDocument)) return console.error(`Shadowrun 5e | ${this.type} got a target that is no TokenDocument`, token);
             if (!token.actor) return console.error(`Shadowrun 5e | ${this.type} got a token that has no actor`, token);
-            this.data.targetActorsUuid = this.data.targetActorsUuid.filter(uuid => uuid === token.actor?.uuid);
+            this.data.targetActorsUuid = [token.actor.uuid];
+            this.targets = [token];
         }
 
         // Alter test data for range.
@@ -257,7 +258,6 @@ export class RangedAttackTest extends SuccessTest {
      * Ranged attack tests allow for temporarily changing of modifiers without altering the document.
      */
     override prepareTestModifiers() {
-        
         this.prepareEnvironmentalModifier();
     }
 

--- a/src/module/tests/SuccessTest.ts
+++ b/src/module/tests/SuccessTest.ts
@@ -157,7 +157,6 @@ export class SuccessTest {
     public actor: SR5Actor | undefined;
     public item: SR5Item | undefined;
     public rolls: SR5Roll[];
-
     public targets: TokenDocument[];
 
     constructor(data, documents?: TestDocuments, options?: TestOptions) {
@@ -649,7 +648,7 @@ export class SuccessTest {
      * This can happen when a test is created from a ChatMessage.
      */
     async populateDocuments() {
-        // Fetch documents, when no reference has been made yet.
+        // Populate the actor document.
         if (!this.actor && this.data.sourceActorUuid) {
             // SR5Actor.uuid will return an actor id for linked actors but its token id for unlinked actors
             const document = await fromUuid(this.data.sourceActorUuid) || undefined;
@@ -658,8 +657,12 @@ export class SuccessTest {
                 document.actor :
                 document as SR5Actor;
         }
+
+        // Populate the item document.
         if (!this.item && this.data.sourceItemUuid)
             this.item = await fromUuid(this.data.sourceItemUuid) as SR5Item || undefined;
+
+        // Populate targeted token documents.
         if (this.targets.length === 0 && this.data.targetActorsUuid) {
             this.targets = [];
             for (const uuid of this.data.targetActorsUuid) {

--- a/src/module/types/global.d.ts
+++ b/src/module/types/global.d.ts
@@ -1,7 +1,7 @@
 import ShadowrunItemData = Shadowrun.ShadowrunItemData;
 import ShadowrunActorData = Shadowrun.ShadowrunActorData;
-import {SR5Item} from "../item/SR5Item";
-import {SR5Actor} from "../actor/SR5Actor";
+import { SR5Item } from "../item/SR5Item";
+import { SR5Actor } from "../actor/SR5Actor";
 import { SR5Combat } from "../combat/SR5Combat";
 import { SR5ActiveEffect } from "../effect/SR5ActiveEffect";
 import { SR5Roll } from "../rolls/SR5Roll";
@@ -49,7 +49,15 @@ declare global {
         };
     }
 
-    type RecursivePartial<T> = { 
-        [P in keyof T]?: RecursivePartial<T[P]>; 
+    type RecursivePartial<T> = {
+        [P in keyof T]?: RecursivePartial<T[P]>;
     };
+
+
+    /**
+     * Retrieve an Entity or Embedded Entity by its Universally Unique Identifier (uuid).
+     * @param uuid - The uuid of the Entity or Embedded Entity to retrieve
+     */
+    declare function fromUuidSync(uuid: string): foundry.abstract.Document<any, any> | null;
+
 }

--- a/src/module/types/template/weapon.ts
+++ b/src/module/types/template/weapon.ts
@@ -14,9 +14,11 @@ declare namespace Shadowrun {
 
     /**
      * Ranges of targeted TokenDocuments.
+     * NOTE: We store uuid instead of a document, as
+     *       to not store that document when calling SuccessTest.toJSON()
      */
     export interface TargetRangeTemplateData {
-        uuid: string
+        tokenUuid: string
         name: string
         distance: number
         unit: string


### PR DESCRIPTION
Due to this the targetActorUuids where always empty, causing them to not be available for any opposed tests.

While opposed tests otherwise worked with only targeted actors, this caused physical defense tests after ranged attacks to not have any targets available and always need selections. Since only ranged attacks have functionality around token targeting, this caused the misinterpretation that targeting doesn't do anything besides showing targets on message.

@Stexinator since you've been working on opposed test not preselecting targets, could you review this PRs assumption that now all opposed tests use targets to roll with, when no token is selected.