### PR TITLE
feature/armor_scroll_fix

### DIFF
--- a/src/css/bundle.scss
+++ b/src/css/bundle.scss
@@ -461,7 +461,7 @@ input[type='text'].display {
     }
 
     .description>.editor {
-        height: 100%;
+        height: 250px;
         min-height: 15em;
         width: 100%;
         color: $color;


### PR DESCRIPTION
This fixes missing scrollbar on the armor discription, the height: 100%; prevented the scrollbar creation on chrome browser, electron app was fine, firefox also did not allow the scrollbar.