### PR TITLE
[BUG] Fix editing of vehicle stats

### DIFF
--- a/src/templates/actor/parts/vehicle/VehicleStatsList.html
+++ b/src/templates/actor/parts/vehicle/VehicleStatsList.html
@@ -3,76 +3,76 @@
     <div class="attributes">
         {{#unless system.vehicle_stats.handling.hidden}}
             {{> "systems/shadowrun5e/dist/templates/actor/parts/attributes/Attribute.html"
-                rollId=(concatStrings "vehicleStat." handling)
-                attributeId=handling
+                rollId="vehicle-stat.handling"
+                attributeId="handling"
                 attribute=system.vehicle_stats.handling
                 attributesPath="system.vehicle_stats"
             }}
         {{/unless}}
         {{#unless system.vehicle_stats.off_road_handling.hidden}}
             {{> "systems/shadowrun5e/dist/templates/actor/parts/attributes/Attribute.html"
-                rollId=(concatStrings "vehicleStat." off_road_handling)
-                attributeId=off_road_handling
+                rollId="vehicle-stat.off_road_handling"
+                attributeId="off_road_handling"
                 attribute=system.vehicle_stats.off_road_handling
                 attributesPath="system.vehicle_stats"
             }}
         {{/unless}}
         {{#unless system.vehicle_stats.speed.hidden}}
             {{> "systems/shadowrun5e/dist/templates/actor/parts/attributes/Attribute.html"
-                rollId=(concatStrings "vehicleStat." speed)
-                attributeId=speed
+                rollId="vehicle-stat.speed"
+                attributeId="speed"
                 attribute=system.vehicle_stats.speed
                 attributesPath="system.vehicle_stats"
             }}
         {{/unless}}
         {{#unless system.vehicle_stats.off_road_speed.hidden}}
             {{> "systems/shadowrun5e/dist/templates/actor/parts/attributes/Attribute.html"
-                rollId=(concatStrings "vehicleStat." off_road_speed)
-                attributeId=off_road_speed
+                rollId="vehicle-stat.off_road_speed"
+                attributeId="off_road_speed"
                 attribute=system.vehicle_stats.off_road_speed
                 attributesPath="system.vehicle_stats"
             }}
         {{/unless}}
         {{#unless system.vehicle_stats.acceleration.hidden}}
             {{> "systems/shadowrun5e/dist/templates/actor/parts/attributes/Attribute.html"
-                rollId=(concatStrings "vehicleStat." acceleration)
-                attributeId=acceleration
+                rollId="vehicle-stat.acceleration"
+                attributeId="acceleration"
                 attribute=system.vehicle_stats.acceleration
                 attributesPath="system.vehicle_stats"
             }}
         {{/unless}}
         {{> "systems/shadowrun5e/dist/templates/actor/parts/attributes/Attribute.html"
             rollId="attribute.body"
-            attributeId='body'
+            attributeId="body"
             attribute=system.attributes.body
         }}
         {{> "systems/shadowrun5e/dist/templates/actor/parts/attributes/Attribute.html"
             rollId="armor"
-            attributeId='armor'
+            attributeId="armor"
             attribute=system.armor
-            attributesPath='system'
+            attributesPath="system"
             label="SR5.Armor"
         }}
         {{#unless system.vehicle_stats.pilot.hidden}}
             {{> "systems/shadowrun5e/dist/templates/actor/parts/attributes/Attribute.html"
-                rollId=(concatStrings "vehicleStat." pilot)
-                attributeId=pilot
+                rollId="vehicle-stat.pilot"
+                attributeId="pilot"
                 attribute=system.vehicle_stats.pilot
                 attributesPath="system.vehicle_stats"
             }}
         {{/unless}}
         {{#unless system.vehicle_stats.sensor.hidden}}
             {{> "systems/shadowrun5e/dist/templates/actor/parts/attributes/Attribute.html"
-                rollId=(concatStrings "vehicleStat." sensor)
-                attributeId=sensor
+                rollId="vehicle-stat.sensor"
+                attributeId="sensor"
                 attribute=system.vehicle_stats.sensor
                 attributesPath="system.vehicle_stats"
             }}
         {{/unless}}
         {{#unless system.vehicle_stats.seats.hidden}}
             {{> "systems/shadowrun5e/dist/templates/actor/parts/attributes/Attribute.html"
-                rollId=(concatStrings "vehicleStat." seats)
-                attributeId=seats
+                rollId="vehicle-stat.seats"
+                attributeId="seats"
                 attribute=system.vehicle_stats.seats
                 attributesPath="system.vehicle_stats"
             }}


### PR DESCRIPTION
Resolves #1073 

Recent changes made in #1029 broke editing of vehicle stats for all stats except Body and Armor. This changeset restores the correct behavior.

Note - the `rollId` field has no effect for all vehicle stats except body and armor.  There is a stub implementation at [SR5BaseActorSheet.ts#685](https://github.com/SR5-FoundryVTT/SR5-FoundryVTT/blob/master/src/module/actor/sheets/SR5BaseActorSheet.ts#L685).