### PR TITLE
[Feature] add getSkillByLabel fallback for getSkill when not found

### DIFF
--- a/src/module/actor/SR5Actor.ts
+++ b/src/module/actor/SR5Actor.ts
@@ -710,6 +710,8 @@ export class SR5Actor extends Actor {
                 }
             }
         }
+
+        return this.getSkillByLabel(id)
     }
 
     /**
@@ -726,11 +728,6 @@ export class SR5Actor extends Actor {
 
         const skills = this.getSkills();
 
-        for (const [id, skill] of Object.entries(skills.active)) {
-            if (searchedFor === possibleMatch(skill))
-                return {...skill, id};
-        }
-
         for (const [id, skill] of Object.entries(skills.language.value)) {
             if (searchedFor === possibleMatch(skill))
                 return {...skill, id};
@@ -745,6 +742,11 @@ export class SR5Actor extends Actor {
                 if (searchedFor === possibleMatch(skill))
                     return {...skill, id};
             }
+        }
+
+        for (const [id, skill] of Object.entries(skills.active)) {
+            if (searchedFor === possibleMatch(skill))
+                return {...skill, id};
         }
     }
 


### PR DESCRIPTION
addresses https://github.com/SR5-FoundryVTT/SR5-FoundryVTT/issues/1168

I orderd getSkillByLabel according to expected amount. The number of entries should be so low anyway that it should have no impact on performance

Additionally, this enabled to use TeamworkTests with the displayed name instead of the internal id, making it easier to use for non-english speaker