### PR TITLE
[Feature] add ActiveEffect item type

### DIFF
--- a/src/module/config.ts
+++ b/src/module/config.ts
@@ -7,6 +7,7 @@
 export const SR5 = {
     itemTypes: {
         action: 'SR5.ItemTypes.Action',
+        active_effect: 'SR5.ItemTypes.ActiveEffect',
         adept_power: 'SR5.ItemTypes.AdeptPower',
         ammo: 'SR5.ItemTypes.Ammo',
         armor: 'SR5.ItemTypes.Armor',

--- a/src/module/types/ShadowrunItemData.ts
+++ b/src/module/types/ShadowrunItemData.ts
@@ -16,6 +16,7 @@ declare namespace Shadowrun {
     // Register your global ItemData types here.  Try sorting your ItemData types alphabetically.
     export type ShadowrunItemData =
         | ActionItemData
+        | ActiveEffectItemData
         | AdeptPowerItemData
         | AmmoItemData
         | ArmorItemData
@@ -61,6 +62,7 @@ declare namespace Shadowrun {
      */
     export type ShadowrunItemDataData =
         Partial<ActionData> &
+        Partial<ActiveEffectData> &
         Partial<AdeptPowerData> &
         Partial<AmmoData> &
         Partial<ArmorData> &
@@ -90,6 +92,14 @@ declare namespace Shadowrun {
         img: string;
         data: ActionData;
         system: ActionData;
+    }
+
+    export interface ActiveEffectItemData {
+        type: 'active_effect';
+        name: string;
+        img: string;
+        data: ActiveEffectData;
+        system: ActiveEffectData;
     }
 
     export interface AdeptPowerItemData {

--- a/src/module/types/item/ActiveEffect.ts
+++ b/src/module/types/item/ActiveEffect.ts
@@ -1,0 +1,13 @@
+declare namespace Shadowrun {
+    export interface ActiveEffectData extends
+    ActiveEffectPartData,
+    ImportFlags,
+    DescriptionPartData{
+
+    }
+
+    export interface ActiveEffectPartData {
+
+    }
+
+}

--- a/src/templates/item/active_effect.html
+++ b/src/templates/item/active_effect.html
@@ -1,0 +1,16 @@
+<form class="{{cssClass}} wholesheet" autocomplete="off">
+    {{> "systems/shadowrun5e/dist/templates/item/parts/header.html" }}
+    <nav class="tabs" data-group="primary">
+        <a class="item" data-tab="description">{{localize "SR5.Description"}}</a>
+        <!--<a class="item" data-tab="info">{{localize "SR5.Information"}}</a>-->
+        <a class="item" data-tab="effects">{{ localize "SR5.Effects" }}</a>
+    </nav>
+    <section class="sheetbody">
+        <div class="tab" data-group="primary" data-tab="description">
+            <div class="flexrow align-start nowrap full-height">
+                {{> "systems/shadowrun5e/dist/templates/item/parts/description.html"}}
+            </div>
+        </div>
+        {{> "systems/shadowrun5e/dist/templates/actor/tabs/EffectsTab.html"}}
+    </section>
+</form>

--- a/template.json
+++ b/template.json
@@ -1168,6 +1168,7 @@
     "Item": {
         "types": [
             "action",
+            "active_effect",
             "adept_power",
             "ammo",
             "armor",
@@ -1631,6 +1632,9 @@
         },
         "echo" : {
             "templates": ["description", "importFlags"]
+        },
+        "active_effect": {
+            "templates": ["description"]
         }
     }
 }


### PR DESCRIPTION
The long term goal is to add drag and drop functionality to add it into items/actors. When dropping the item should automatically convert into the effect without being an item. For this I need a manual how to create active effects programatically