### PR TITLE
#1171 - Drone Modifications support

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-    "name": "SR5-FoundryVTT-1171",
+    "name": "SR5-FoundryVTT",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-    "name": "SR5-FoundryVTT",
+    "name": "SR5-FoundryVTT-1171",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {

--- a/public/locale/en/config.json
+++ b/public/locale/en/config.json
@@ -760,6 +760,7 @@
         "WoundTolerance": "Wound Tolerance",
         "Wounds": "Wounds"
     },
+    "SR5.ModPoints": "Mod Points",
     "SR5.MountPoint": "Mount Point",
     "SR5.MoveInventoryDialog": {
         "Cancel": "Cancel",
@@ -811,8 +812,8 @@
     "SR5.PowerType": "Type",
     "SR5.Powers": "Powers",
     "SR5.Program": "Program",
-    "SR5.ProgramType": "Type",
     "SR5.Programs": "Programs",
+    "SR5.ProgramType": "Type",    
     "SR5.PublicAwareness": "Public Awareness",
     "SR5.PushTheLimit": "Push The Limit",
     "SR5.Qty": "Qty",
@@ -1325,6 +1326,7 @@
             "Rigger": "Rigger"
         },
         "Driver": "Driver",
+        "Drone": "Drone",
         "Environments": {
             "Handling": "Handling",
             "Speed": "Speed"

--- a/src/module/config.ts
+++ b/src/module/config.ts
@@ -633,7 +633,8 @@ export const SR5 = {
     modificationTypes: {
         weapon: 'SR5.Weapon.Weapon',
         armor: 'SR5.Armor',
-        vehicle: 'SR5.Vehicle.Vehicle'
+        vehicle: 'SR5.Vehicle.Vehicle',
+        drone: 'SR5.Vehicle.Drone'
     },
 
     mountPoints: {

--- a/src/module/data/SR5ItemDataWrapper.ts
+++ b/src/module/data/SR5ItemDataWrapper.ts
@@ -91,6 +91,12 @@ export class SR5ItemDataWrapper extends DataWrapper<ShadowrunItemData> {
         return modification.system.type === 'vehicle';
     }
 
+    isDroneModification(): boolean {
+        if (!this.isModification()) return false;
+        const modification = this.data as ModificationItemData;
+        return modification.system.type === 'drone';
+    }
+
     isProgram(): boolean {
         return this.data.type === 'program';
     }

--- a/src/module/handlebars/ActorHelpers.ts
+++ b/src/module/handlebars/ActorHelpers.ts
@@ -43,8 +43,9 @@ export const registerActorHelpers = () => {
     */
     Handlebars.registerHelper('calcModPointSlots', (items: [SR5Item]): number => {
         if (!Array.isArray(items) || !items.length) { return 0 }
-        const slotSum = items.reduce((arr, item) => {
-            if (item.system.type == 'drone') { return arr += item.system.slots ? item.system.slots : 0 } else { return arr };
+        var dronestring = 'drone';
+        const slotSum = items.reduce((arr, item) => {            
+            if (item.system.type == dronestring) { return arr += item.system.slots ? item.system.slots : 0 } else { return arr };            
         }, 0)
 
         return slotSum;

--- a/src/module/handlebars/ActorHelpers.ts
+++ b/src/module/handlebars/ActorHelpers.ts
@@ -36,5 +36,19 @@ export const registerActorHelpers = () => {
         return slotSum;
     });
 
+    /** 
+    * Determine the amount of Mod Points slots in use by a Vehicle actor (Drone)
+    * 
+    * @param items The items to be considered
+    */
+    Handlebars.registerHelper('calcModPointSlots', (items: [SR5Item]): number => {
+        if (!Array.isArray(items) || !items.length) { return 0 }
+        const slotSum = items.reduce((arr, item) => {
+            if (item.system.type == 'drone') { return arr += item.system.slots ? item.system.slots : 0 } else { return arr };
+        }, 0)
+
+        return slotSum;
+    });
+
 
 }

--- a/src/module/handlebars/ItemLineHelpers.ts
+++ b/src/module/handlebars/ItemLineHelpers.ts
@@ -497,7 +497,18 @@ export const registerItemLineHelpers = () => {
                         },
                         qtyInput,
                     ];
-                }                                
+                };
+
+                if (wrapper.isDroneModification()) {
+                    return [                        
+                        {
+                            text: {
+                                text: wrapper.getModificationCategorySlots() ?? ''
+                            },
+                        },
+                        qtyInput,
+                    ];
+                }
             case 'device':
             case 'equipment':
             case 'cyberware':

--- a/src/module/item/SR5ItemSheet.ts
+++ b/src/module/item/SR5ItemSheet.ts
@@ -50,6 +50,7 @@ interface SR5ItemSheetData extends SR5BaseItemSheetData {
     weaponMods: Shadowrun.ModificationItemData[]
     armorMods: Shadowrun.ModificationItemData[]
     vehicleMods: Shadowrun.ModificationItemData[]
+    droneMods: Shadowrun.ModificationItemData[]
 
     // Sorted lists for usage in select elements.
     activeSkills: Record<string, string> // skill id: label
@@ -153,8 +154,8 @@ export class SR5ItemSheet extends ItemSheet {
         /**
          * Reduce nested items into typed lists.
          */
-        const [ammunition, weaponMods, armorMods, vehicleMods] = this.item.items.reduce(
-            (sheetItemData: [Shadowrun.AmmoItemData[], Shadowrun.ModificationItemData[], Shadowrun.ModificationItemData[], Shadowrun.ModificationItemData[]], nestedItem: SR5Item) => {
+        const [ammunition, weaponMods, armorMods, vehicleMods, droneMods] = this.item.items.reduce(
+            (sheetItemData: [Shadowrun.AmmoItemData[], Shadowrun.ModificationItemData[], Shadowrun.ModificationItemData[], Shadowrun.ModificationItemData[], Shadowrun.ModificationItemData[]], nestedItem: SR5Item) => {
                 const itemData = nestedItem.toObject();
                 //@ts-expect-error
                 itemData.descriptionHTML = this.enrichEditorFieldToHTML(itemData.system.description.value);
@@ -167,15 +168,18 @@ export class SR5ItemSheet extends ItemSheet {
                 if (nestedItem.type === 'modification' && "type" in nestedItem.system && nestedItem.system.type === 'armor') sheetItemData[2].push(itemData);
                 //@ts-expect-error TODO: foundry-vtt-types v10
                 if (nestedItem.type === 'modification' && "type" in nestedItem.system && nestedItem.system.type === 'vehicle') sheetItemData[3].push(itemData);
+                //@ts-expect-error TODO: foundry-vtt-types v10
+                if (nestedItem.type === 'modification' && "type" in nestedItem.system && nestedItem.system.type === 'drone') sheetItemData[4].push(itemData);
 
                 return sheetItemData;
             },
-            [[], [], [], []],
+            [[], [], [], [], []],
         );
         data['ammunition'] = ammunition;
         data['weaponMods'] = weaponMods;
         data['armorMods'] = armorMods;
         data['vehicleMods'] = vehicleMods;
+        data['droneMods'] = droneMods;
         data['activeSkills'] = this._getSortedActiveSkillsForSelect();
         data['attributes'] = this._getSortedAttributesForSelect();
         data['limits'] = this._getSortedLimitsForSelect();

--- a/src/module/types/actor/Vehicle.ts
+++ b/src/module/types/actor/Vehicle.ts
@@ -34,7 +34,8 @@ declare namespace Shadowrun {
             attributes: VehicleAttributes
             networkController: string
             modifiers: Modifiers & CommonModifiers
-            modificationCategories: VehicleModCategories          
+            modificationCategories: VehicleModCategories
+            modPoints: number
         }
 
     export interface VehicleStats {

--- a/src/module/types/item/Modification.ts
+++ b/src/module/types/item/Modification.ts
@@ -12,7 +12,7 @@ declare namespace Shadowrun {
      * Fields to modify matching parent item fields with during item preparation
      */
     export interface ModificationPartType {
-        type: 'weapon' | 'armor' | 'vehicle' | ''
+        type: 'weapon' | 'armor' | 'vehicle' | 'drone' | ''
         mount_point: MountType
         modification_category: ModificationCategoryType
         dice_pool: number

--- a/src/templates/actor/parts/vehicle/VehicleSecondStatsList.html
+++ b/src/templates/actor/parts/vehicle/VehicleSecondStatsList.html
@@ -1,7 +1,5 @@
-<div class="flexcol scroll-area">
-    {{> "systems/shadowrun5e/dist/templates/common/HeaderBlock.html"
-            name=(localize "SR5.Labels.ActorSheet.VehicleConfiguration")
-    }}
+<div class="flexcol">
+    {{> "systems/shadowrun5e/dist/templates/common/HeaderBlock.html" name=(localize "SR5.Labels.ActorSheet.VehicleConfiguration")}}
     {{#> "systems/shadowrun5e/dist/templates/common/NameLineBlock.html" name=(localize "SR5.Vehicle.Driver") }}
     <div>
         {{#if vehicle.driver}}
@@ -60,8 +58,16 @@
     {{/if}}
     {{/"systems/shadowrun5e/dist/templates/common/NameLineBlock.html"}}
 
+    {{#if system.isDrone}}
+    {{> "systems/shadowrun5e/dist/templates/common/HeaderBlock.html" name=(localize "SR5.ModPoints")}}
+    {{#> "systems/shadowrun5e/dist/templates/common/NameLineBlock.html" name=(localize "SR5.ModPoints") }}
+    <span style="white-space: nowrap">
+        {{calcModPointSlots items}} /
+    </span>
+    <input class="display" type="text" size="5" name="system.modPoints" value="{{system.modPoints}}" data-dtype="Number" />
+    {{/"systems/shadowrun5e/dist/templates/common/NameLineBlock.html"}}
+    {{else}}
     {{> "systems/shadowrun5e/dist/templates/common/HeaderBlock.html" name=(localize "SR5.ModificationCategories")}}
-
     {{#> "systems/shadowrun5e/dist/templates/common/NameLineBlock.html" name=(localize "SR5.Vehicle.ModificationCategoryTypes.body") }}
     <span style="white-space: nowrap">
         {{calcModificationCategorySlots items "body"}} /
@@ -98,4 +104,6 @@
     </span>
     <input class="display" type="text" size="5" name="system.modificationCategories.weapons" value="{{system.modificationCategories.weapons}}" data-dtype="Number" />
     {{/"systems/shadowrun5e/dist/templates/common/NameLineBlock.html"}}
+    {{/if}}
+
 </div>

--- a/src/templates/item/parts/modification.html
+++ b/src/templates/item/parts/modification.html
@@ -48,15 +48,13 @@
             {{localize "SR5.Accuracy"}}
         </div>
         <div class="inputs">
-            <input 
-                   type="text"
+            <input type="text"
                    maxlength="2"
                    size="2"
                    name="system.accuracy"
                    value="{{system.accuracy}}"
                    data-dtype="Number"
-                   placeholder="Accuracy" 
-                   />
+                   placeholder="Accuracy" />
         </div>
     </div>
     <div class="form-line">
@@ -101,6 +99,22 @@
     <div class="form-line">
         <div class="label">
             {{localize "SR5.ModificationSlots"}}
+        </div>
+        <div class="inputs">
+            <input type="text"
+                   maxlength="2"
+                   size="5"
+                   name="system.slots"
+                   value="{{system.slots}}"
+                   data-dtype="Number"
+                   placeholder="Slots" />
+        </div>
+    </div>
+    {{/ife}}
+    {{#ife system.type 'drone'}}   
+    <div class="form-line">
+        <div class="label">
+            {{localize "SR5.ModPoints"}}
         </div>
         <div class="inputs">
             <input type="text"

--- a/template.json
+++ b/template.json
@@ -1049,12 +1049,13 @@
             "driver": "",
             "modificationCategories": {
                 "body": 0,
-                "power_tain": 0,
+                "power_train": 0,
                 "protection": 0,
                 "electromagnetic": 0,
                 "cosmetic": 0,
                 "weapons": 0
-            },          
+            },   
+            "modPoints": 0,
             "vehicle_stats": {
                 "pilot": {
                     "base": 0,


### PR DESCRIPTION
- Added 'drone' Gear Modification type
   - Slots only, no Modification Categories
- Updated Vehicle modifications for Drones:
   - Adjusted appearance of Modification Categories so it only appears when Vehicle is not a drone
   - Added Mod Points section to appear when Vehicle is a drone
   - Added Mod Points field
   - Added mod points lots used calculation

Bug Fix:
- Added default value for power_train mod category (0)