### PR TITLE
Fix adding linked token actors to Overwatch Score Monitor

### DIFF
--- a/src/module/apps/gmtools/OverwatchScoreTracker.js
+++ b/src/module/apps/gmtools/OverwatchScoreTracker.js
@@ -73,15 +73,15 @@ export class OverwatchScoreTracker extends Application {
         }
 
         // Warn user about selected unlinked token actors.
-        const unlinkedActor = tokens.find(token => !token.data.actorLink);
+        const unlinkedActor = tokens.find(token => !token.document.actorLink);
         if (unlinkedActor !== undefined) {
             ui.notifications.warn(game.i18n.localize('SR5.OverwatchScoreTracker.OnlyLinkedActorsSupported'));
         }
 
         // Add linked token actors.
-        tokens.filter(token => token.data.actorLink).forEach(token => {
+        tokens.filter(token => token.document.actorLink).forEach(token => {
             // Double check that the actor actually lives in the actors collection.
-            const actor = game.actors.get(token.data.actorId);
+            const actor = game.actors.get(token.document.actorId);
             if (!actor) return;
             if (this._isActorOnTracker(actor)) return;
 


### PR DESCRIPTION
Fixes issue #1237

Foundry v12 removed .data support, causing token.data.actorLink to fail.
Test both in v12 and v11.