### PR TITLE
[BUG] Spirit Importer Button is gone

### DIFF
--- a/src/module/handlebars/BasicHelpers.ts
+++ b/src/module/handlebars/BasicHelpers.ts
@@ -201,15 +201,26 @@ export const registerBasicHelpers = () => {
     });
 
     /**
-     * Allow to give two values and either use the first or the second.
+     * Allow to give two values and compare them with logical OR.
      * 
-     * This matches a ?? b behavior.
+     * Uses JavaScript truthy/falsy values.
      * 
-     * @param a The first value, use this if it's not undefined.
-     * @param v The second value, use this if a is undefined.
-     * @returns the value to use
+     * @param a The first value
+     * @param v The second value
+     * @returns true or false
      */
     Handlebars.registerHelper('or', function(a, b) {
-        return a ?? b;
+        return a || b;
+    });
+
+    /**
+     * Allow using the first given value that's defined.
+     * @params * A open list of parameters, from which the first defined value will be returned.
+     */
+    Handlebars.registerHelper('firstDefined', function(...values) {
+        for (const value of values) {
+            if (value !== undefined) return value;
+        }
+        return undefined;
     });
 };

--- a/src/templates/actor/tabs/EffectsTab.html
+++ b/src/templates/actor/tabs/EffectsTab.html
@@ -11,7 +11,7 @@
         }}
         {{#each effects}}
         {{> 'systems/shadowrun5e/dist/templates/common/List/ListItem.html'
-            img=(or this.img this.icon)
+            img=(firstDefined this.img this.icon)
             name=this.name
             itemId=this.id
             icons=(EffectIcons this)
@@ -31,7 +31,7 @@
         }}
         {{#each itemEffects}}
         {{> 'systems/shadowrun5e/dist/templates/common/List/ListItem.html'
-            img=(or this.img this.icon)
+            img=(firstDefined this.img this.icon)
             name=this.sheetName
             itemId=this.uuid
             icons=(ItemEffectIcons this)


### PR DESCRIPTION
Mistaken use of Handlebar helper or 
Refactor or for boolean comparisons to avoid future missuse.
Implement firstDefined instead of previous or for using the first defined value, extending it's use from two to n params.

Fixes #1294