### PR TITLE
[Feature] Implement spare clip types und partial reloading

### DIFF
--- a/public/locale/de/config.json
+++ b/public/locale/de/config.json
@@ -1413,6 +1413,16 @@
             "Range": "Fernkampf",
             "Thrown": "Geworfen"
         },
+        "Cliptype": {
+            "RemovableClip": "Ladestreifen",
+            "BreakAction": "Klapplademechanismus",
+            "BeltFed": "Gurtmunition",
+            "InternalMagazin": "Internes Magazin",
+            "MuzzleLoader": "Vorderlader",
+            "Cylinder": "Aufklappbare Trommel",
+            "Drum": "Große Trommel",
+            "Bow": "Bogen"
+        },
         "Mod": "Mod",
         "Mode": {
             "BurstFire": "SM",
@@ -1469,6 +1479,8 @@
         },
         "Reach": "Reichweite",
         "Reload": "Nachladen",
+        "FullReload": "Komplett",
+        "PartialReload": "Teilweise",
         "Type": "Typ",
         "Weapon": "Waffen"
     },

--- a/public/locale/en/config.json
+++ b/public/locale/en/config.json
@@ -1397,6 +1397,7 @@
         "CantRecoverPhysicalWithStunDamage": "Cant recover from physical damage with stun damage still present",
         "CantReloadAtAllDueToAmmo": "You have no ammo left!",
         "CantReloadFullyDueToAmmo": "You didn't have enough ammo to fully reload!",
+        "CantReloadPartialDueToAmmo": "You didn't have enough ammo for a complex reload action!",
         "CantReloadWithoutSpareClip": "You're out of spare clips!",
         "CantSecondChanceAGlitch": "Can't second chance this test. Test result is glitched.",
         "CantSecondChanceWithoutNoneHits": "Can't second chance this test. Only hit-dice left.",
@@ -1422,6 +1423,16 @@
             "Melee": "Melee",
             "Range": "Range",
             "Thrown": "Thrown"
+        },
+        "Cliptype": {
+            "RemovableClip": "Removable Clip",
+            "BreakAction": "Break Action",
+            "BeltFed": "Belt Fed",
+            "InternalMagazin": "Internal Magazin",
+            "MuzzleLoader": "Muzzle Loader",
+            "Cylinder": "Cylinder",
+            "Drum": "Drum",
+            "Bow": "Bow"
         },
         "Mod": "Mod",
         "Mode": {
@@ -1479,6 +1490,8 @@
         },
         "Reach": "Reach",
         "Reload": "Reload",
+        "FullReload": "Full",
+        "PartialReload": "Partial",
         "Type": "Type",
         "Weapon": "Weapon"
     },

--- a/src/module/actor/sheets/SR5BaseActorSheet.ts
+++ b/src/module/actor/sheets/SR5BaseActorSheet.ts
@@ -237,7 +237,7 @@ export class SR5BaseActorSheet extends ActorSheet {
 
         data.itemType = await this._prepareItemTypes(data);
         data.effects = prepareSortedEffects(this.actor.effects.contents);
-        data.itemEffects = prepareSortedItemEffects(this.actor, {applyTo: this.itemEffectApplyTos});
+        data.itemEffects = prepareSortedItemEffects(this.actor, { applyTo: this.itemEffectApplyTos });
         data.inventories = await this._prepareItemsInventory();
         data.inventory = this._prepareSelectedInventory(data.inventories);
         data.hasInventory = this._prepareHasInventory(data.inventories);
@@ -353,7 +353,8 @@ export class SR5BaseActorSheet extends ActorSheet {
         html.find('.import-character').on('click', this._onShowImportCharacter.bind(this));
 
         // Misc. item type actions...
-        html.find('.reload-ammo').on('click', this._onReloadAmmo.bind(this));
+        html.find('.reload-ammo').on('click', async (event) => this._onReloadAmmo(event, false));
+        html.find('.partial-reload-ammo').on('click', async (event) => this._onReloadAmmo(event, true));
         html.find('.matrix-att-selector').on('change', this._onMatrixAttributeSelected.bind(this));
 
         // Situation modifiers application
@@ -1671,11 +1672,11 @@ export class SR5BaseActorSheet extends ActorSheet {
      *
      * @param event
      */
-    async _onReloadAmmo(event) {
+    async _onReloadAmmo(event, partialReload: boolean) {
         event.preventDefault();
         const iid = Helpers.listItemId(event);
         const item = this.actor.items.get(iid);
-        if (item) return item.reloadAmmo();
+        if (item) return item.reloadAmmo(partialReload);
     }
 
     /**

--- a/src/module/actor/sheets/SR5BaseActorSheet.ts
+++ b/src/module/actor/sheets/SR5BaseActorSheet.ts
@@ -1419,13 +1419,13 @@ export class SR5BaseActorSheet extends ActorSheet {
         await this.actor.showHiddenSkills();
     }
 
-    _onOpenSource(event) {
+    async _onOpenSource(event) {
         event.preventDefault();
         const field = $(event.currentTarget).parents('.list-item');
         const iid = $(field).data().itemId;
         const item = this.actor.items.get(iid);
         if (item) {
-            item.openSource();
+            await item.openSource();
         }
     }
     /**

--- a/src/module/apps/skills/SkillEditSheet.ts
+++ b/src/module/apps/skills/SkillEditSheet.ts
@@ -2,6 +2,7 @@ import SkillEditFormData = Shadowrun.SkillEditFormData;
 import {SR5Actor} from "../../actor/SR5Actor";
 import {SR5} from "../../config";
 import { LinksHelpers } from "../../utils/links";
+import { parseDropData } from "../../utils/sheets";
 import { Translation } from '../../utils/strings';
 
 export class SkillEditSheet extends DocumentSheet {
@@ -114,6 +115,15 @@ export class SkillEditSheet extends DocumentSheet {
 
     override activateListeners(html) {
         super.activateListeners(html);
+
+        /**
+         * Drag and Drop Handling
+         */
+        //@ts-expect-error
+        this.form.ondragover = (event) => this._onDragOver(event);
+        //@ts-expect-error
+        this.form.ondrop = (event) => this._onDrop(event);
+
         $(html).find('.open-source').on('click', this._onOpenSource.bind(this));
         $(html).find('.add-spec').on('click', this._addNewSpec.bind(this));
         $(html).find('.remove-spec').on('click', this._removeSpec.bind(this));
@@ -130,6 +140,19 @@ export class SkillEditSheet extends DocumentSheet {
         // add blank line for new bonus
         updateData[`${this._updateString()}.bonus`] = [...bonus, { key: '', value: 0 }];
         await this.document.update(updateData);
+    }
+
+    override async _onDrop(event) {
+        if (!game.items || !game.actors || !game.scenes) return;
+
+        event.preventDefault();
+        event.stopPropagation();
+
+        // Parse drop data.
+        const data = parseDropData(event);
+        if (!data) return;
+
+        this.document.update({[`${this._updateString()}.link`]: data.uuid});
     }
 
     async _removeBonus(event) {

--- a/src/module/config.ts
+++ b/src/module/config.ts
@@ -434,6 +434,17 @@ export const SR5 = {
         thrown: 'SR5.Weapon.Category.Thrown',
     },
 
+    weaponCliptypes: {
+        removable_clip: 'SR5.Weapon.Cliptype.RemovableClip',
+        break_action:'SR5.Weapon.Cliptype.BreakAction',
+        belt_fed:'SR5.Weapon.Cliptype.BeltFed',
+        internal_magazin:'SR5.Weapon.Cliptype.InternalMagazin',
+        muzzle_loader:'SR5.Weapon.Cliptype.MuzzleLoader',
+        cylinder:'SR5.Weapon.Cliptype.Cylinder',
+        drum:'SR5.Weapon.Cliptype.Drum',
+        bow:'SR5.Weapon.Cliptype.Bow',
+    },
+
     weaponRanges: {
         short: 'SR5.Weapon.Range.Short',
         medium: 'SR5.Weapon.Range.Medium',

--- a/src/module/item/SR5Item.ts
+++ b/src/module/item/SR5Item.ts
@@ -1215,7 +1215,7 @@ export class SR5Item extends Item {
 
     setSource(source: string) {
         if (!this.system.description) this.system.description = { chat: '', source: '', value: '' };
-        this.system.description.source = source;
+        this.update({'system.description.source': source});
         this.render(true);
     }
 

--- a/src/module/item/SR5Item.ts
+++ b/src/module/item/SR5Item.ts
@@ -1207,6 +1207,12 @@ export class SR5Item extends Item {
         return this.wrapper.getSource();
     }
 
+    setSource(source: string) {
+        if (!this.system.description) this.system.description = { chat: '', source: '', value: '' };
+        this.system.description.source = source;
+        this.render(true);
+    }
+
     getConditionMonitor(): ConditionData {
         return this.wrapper.getConditionMonitor();
     }

--- a/src/module/item/SR5Item.ts
+++ b/src/module/item/SR5Item.ts
@@ -914,13 +914,19 @@ export class SR5Item extends Item {
         await LinksHelpers.openSource(source);
     }
 
-    /**
-     * Determine if the items source field points to a URL instead of an PDF code.
-     * @returns true if the source field is a URL.
-     */
     get sourceIsUrl(): boolean {
         const source = this.getSource();
         return LinksHelpers.isURL(source);
+    }
+
+    get sourceIsPDF(): boolean {
+        const source = this.getSource();
+        return LinksHelpers.isPDF(source);
+    }
+
+    get sourceIsUuid(): boolean {
+        const source = this.getSource();
+        return LinksHelpers.isUuid(source);
     }
 
     _canDealDamage(): boolean {

--- a/src/module/item/SR5Item.ts
+++ b/src/module/item/SR5Item.ts
@@ -510,7 +510,7 @@ export class SR5Item extends Item {
             return ui.notifications?.warn('SR5.Warnings.CantReloadAtAllDueToAmmo', { localize: true });
         }
         if (ammo && Number(ammo.system.technology?.quantity) < missingBullets) {
-            if(partialReload && partialReloadBulletsNeeded != -1 && Number(ammo.system.technology?.quantity) < partialReloadBulletsNeeded ) {
+            if(partialReload && partialReloadBulletsNeeded !== -1 && Number(ammo.system.technology?.quantity) < partialReloadBulletsNeeded ) {
                 ui.notifications?.info('SR5.Warnings.CantReloadPartialDueToAmmo', { localize: true });
             } else {
                 ui.notifications?.info('SR5.Warnings.CantReloadFullyDueToAmmo', { localize: true });

--- a/src/module/item/SR5Item.ts
+++ b/src/module/item/SR5Item.ts
@@ -909,9 +909,9 @@ export class SR5Item extends Item {
     /**
      * Use the items source field and try different means of opening it.
      */
-    openSource() {
+    async openSource() {
         const source = this.getSource();
-        LinksHelpers.openSource(source);
+        await LinksHelpers.openSource(source);
     }
 
     /**

--- a/src/module/item/SR5ItemSheet.ts
+++ b/src/module/item/SR5ItemSheet.ts
@@ -351,6 +351,7 @@ export class SR5ItemSheet extends ItemSheet {
         const data = this.parseDropData(event);
         if (!data) return;
 
+        // Handle dropping of documents directly into the source field like urls and pdfs.
         if (event.toElement.name === 'system.description.source') {
             this.item.setSource(data.uuid);
             return;
@@ -414,9 +415,9 @@ export class SR5ItemSheet extends ItemSheet {
         return event.currentTarget.closest('.list-item').dataset.itemId;
     }
 
-    _onOpenSource(event) {
+    async _onOpenSource(event) {
         event.preventDefault();
-        this.item.openSource();
+        await this.item.openSource();
     }
 
     async _onSelectRangedRangeCategory(event) {

--- a/src/module/item/SR5ItemSheet.ts
+++ b/src/module/item/SR5ItemSheet.ts
@@ -583,7 +583,7 @@ export class SR5ItemSheet extends ItemSheet {
     }
 
     async _onOwnedItemRemove(event) {
-        event.preventDefault(); 1
+        event.preventDefault();
 
         const userConsented = await Helpers.confirmDeletion();
         if (!userConsented) return;

--- a/src/module/item/SR5ItemSheet.ts
+++ b/src/module/item/SR5ItemSheet.ts
@@ -2,7 +2,7 @@ import { Helpers } from '../helpers';
 import { SR5Item } from './SR5Item';
 import { SR5 } from "../config";
 import { onManageActiveEffect, prepareSortedEffects, prepareSortedItemEffects } from "../effects";
-import { createTagify } from '../utils/sheets';
+import { createTagify, parseDropData } from '../utils/sheets';
 import { SR5Actor } from '../actor/SR5Actor';
 import { SR5ActiveEffect } from '../effect/SR5ActiveEffect';
 import { ActionFlow } from './flows/ActionFlow';
@@ -352,7 +352,7 @@ export class SR5ItemSheet extends ItemSheet {
         event.stopPropagation();
 
         // Parse drop data.
-        const data = this.parseDropData(event);
+        const data = parseDropData(event);
         if (!data) return;
 
         // Handle dropping of documents directly into the source field like urls and pdfs.
@@ -804,23 +804,6 @@ export class SR5ItemSheet extends ItemSheet {
 
         this._createActionModifierTagify(html);
         this._createActionCategoriesTagify(html);
-    }
-
-    /**
-     * Helper to parse FoundryVTT DropData directly from it's source event
-     *
-     * This is a legacy handler for earlier FoundryVTT versions, however it's good
-     * practice to not trust faulty input and inform about.
-     *
-     * @param event
-     * @returns undefined when an DropData couldn't be parsed from it's JSON.
-     */
-    parseDropData(event): any | undefined {
-        try {
-            return JSON.parse(event.dataTransfer.getData('text/plain'));
-        } catch (error) {
-            return console.log('Shadowrun 5e | Dropping a document onto an item sheet caused this error', error);
-        }
     }
 
     /**

--- a/src/module/item/SR5ItemSheet.ts
+++ b/src/module/item/SR5ItemSheet.ts
@@ -351,6 +351,11 @@ export class SR5ItemSheet extends ItemSheet {
         const data = this.parseDropData(event);
         if (!data) return;
 
+        if (event.toElement.name === 'system.description.source') {
+            this.item.setSource(data.uuid);
+            return;
+        }
+
         // Add items to a weapons modification / ammo
         if (this.item.isWeapon && data.type === 'Item') {
             let item;

--- a/src/module/item/SR5ItemSheet.ts
+++ b/src/module/item/SR5ItemSheet.ts
@@ -1,3 +1,4 @@
+import { RangedWeaponRules } from './../rules/RangedWeaponRules';
 import { Helpers } from '../helpers';
 import { SR5Item } from './SR5Item';
 import { SR5 } from "../config";
@@ -306,8 +307,10 @@ export class SR5ItemSheet extends ItemSheet {
          */
         html.find('.add-new-ammo').click(this._onAddNewAmmo.bind(this));
         html.find('.ammo-equip').click(this._onAmmoEquip.bind(this));
+        html.find('select[name="change-ammo"]').on('change', async (event) => this._onAmmoEquip(event.target.value));
         html.find('.ammo-delete').click(this._onAmmoRemove.bind(this));
-        html.find('.ammo-reload').click(this._onAmmoReload.bind(this));
+        html.find('.ammo-reload').on('click', async (event) => this._onAmmoReload(event, false));
+        html.find('select[name="change-clip-type"]').on('change', async (event) => this._onClipEquip(event.target.value));
 
         html.find('.add-new-mod').click(this._onAddWeaponMod.bind(this));
         html.find('.mod-equip').click(this._onWeaponModEquip.bind(this));
@@ -538,17 +541,25 @@ export class SR5ItemSheet extends ItemSheet {
         await this.item.createNestedItem(item._source);
     }
 
-    async _onAmmoReload(event) {
+    async _onAmmoReload(event, partialReload: boolean) {
         event.preventDefault();
-        await this.item.reloadAmmo();
+        await this.item.reloadAmmo(partialReload);
     }
 
     async _onAmmoRemove(event) {
         await this._onOwnedItemRemove(event);
     }
 
-    async _onAmmoEquip(event) {
-        await this.item.equipAmmo(this._eventId(event));
+    async _onAmmoEquip(input) {
+        let id;
+
+        if (input.currentTarget) {
+            id = this._eventId(input);
+        } else {
+            id = input;
+        }
+
+        await this.item.equipAmmo(id);
     }
 
     async _onAddNewAmmo(event) {
@@ -562,6 +573,13 @@ export class SR5ItemSheet extends ItemSheet {
         const item = new SR5Item(itemData, { parent: this.item });
         // @ts-expect-error TODO: foundry-vtt-types v10
         await this.item.createNestedItem(item._source);
+    }
+
+    async _onClipEquip(clipType: string) {
+        await this.item.update({
+            'system.ammo.clip_type': clipType,
+            'system.ammo.partial_reload_value': RangedWeaponRules.partialReload(clipType, this.item.actor.getAttribute('agility').value)
+        }, { render: true });
     }
 
     async _onOwnedItemRemove(event) {

--- a/src/module/item/SR5ItemSheet.ts
+++ b/src/module/item/SR5ItemSheet.ts
@@ -77,6 +77,8 @@ interface SR5ItemSheetData extends SR5BaseItemSheetData {
 
     // Can be used to check if the source field contains a URL.
     sourceIsURL: boolean
+    sourceIsPDF: boolean
+    sourceIsUuid: boolean
 
     isUsingRangeCategory: boolean
 }
@@ -220,6 +222,8 @@ export class SR5ItemSheet extends ItemSheet {
         // @ts-expect-error TODO: foundry-vtt-types v10
         data.descriptionHTML = await this.enrichEditorFieldToHTML(this.item.system.description.value);
         data.sourceIsURL = this.item.sourceIsUrl;
+        data.sourceIsPDF = this.item.sourceIsPDF;
+        data.sourceIsUuid = this.item.sourceIsUuid
 
         data.isUsingRangeCategory = this.item.isUsingRangeCategory;
 

--- a/src/module/item/sheets/SR5CallInActionSheet.ts
+++ b/src/module/item/sheets/SR5CallInActionSheet.ts
@@ -1,4 +1,5 @@
 import { SR5Actor } from "../../actor/SR5Actor";
+import { parseDropData } from "../../utils/sheets";
 import { SR5BaseItemSheetData, SR5ItemSheet } from "../SR5ItemSheet";
 
 
@@ -47,7 +48,7 @@ export class SR5CallInActionSheet extends SR5ItemSheet {
         event.preventDefault();
         event.stopPropagation();
 
-        const data = this.parseDropData(event);
+        const data = parseDropData(event);
         if (!data) return;
 
         if (data.type !== 'Actor') return;

--- a/src/module/rules/RangedWeaponRules.ts
+++ b/src/module/rules/RangedWeaponRules.ts
@@ -28,11 +28,11 @@ export const RangedWeaponRules = {
         if (rangeKey) {
             return ranges[rangeKey];
         } else {
-            const {extreme} = ranges;
+            const { extreme } = ranges;
             return Helpers.createRangeDescription('SR5.OutOfRange', extreme.distance, SR.combat.environmental.range_modifiers.out_of_range);
         }
     },
-    
+
 
     /**
      * Calculate recoil compensation based on SR5#175 'Recoil' including SR5#178
@@ -112,7 +112,28 @@ export const RangedWeaponRules = {
      * Free recoil compensation according to SR5#175 'Recoil'
      * @param baseRc Optional parameter allowing you to define a custom base rc.
      */
-    humanoidBaseRecoilCompensation(baseRc:number=1): number {
+    humanoidBaseRecoilCompensation(baseRc: number = 1): number {
         return baseRc;
+    },
+
+    /**
+     * The number of bullets when reloading during a complex action according to SR5#163 'Reloading Weapons'
+     * @param clip The currently used clip
+     * @param dex The owning actors dexterity value
+     * @returns The number of bullets when reloading during a complex action or -1 if it can only be fully reloaded directly
+     */
+    partialReload(clip: string = '', dex: number = 1): number {
+        switch (clip) {
+            case 'internal_magazin':
+            case 'cylinder':
+                return dex;
+            case 'break_action':
+                return 2;
+            case 'muzzle_loader':
+            case 'bow':
+                return 1;
+            default:
+                return -1;
+        }
     }
 }

--- a/src/module/types/item/Weapon.ts
+++ b/src/module/types/item/Weapon.ts
@@ -33,6 +33,8 @@ declare namespace Shadowrun {
     export interface AmmunitionData {
         spare_clips: ValueMaxPair<number>;
         current: ValueMaxPair<number>;
+        clip_type: 'removable_clip' | 'break_action' | 'belt_fed' | 'internal_magazin' | 'muzzle_loader' | 'cylinder' | 'drum' | 'bow' | '';
+        partial_reload_value: number;
     }
 
     /**

--- a/src/module/utils/links.ts
+++ b/src/module/utils/links.ts
@@ -1,3 +1,6 @@
+import { SR5Actor } from "../actor/SR5Actor";
+import { SR5Item } from "../item/SR5Item";
+
 /**
  * Utils used for opening links
  */
@@ -9,11 +12,26 @@ export class LinksHelpers {
      * @param candidate The string that might contain a url
      * @returns true, when candidate contains a url pattern
      */
-    static isURL(candidate: string|undefined): boolean {
+    static isURL(candidate: string | undefined): boolean {
         if (!candidate) return false;
         var urlRegex = '^(?!mailto:)(?:(?:http|https|ftp)://)?(?:\\S+(?::\\S*)?@)?(?:(?:(?:[1-9]\\d?|1\\d\\d|2[01]\\d|22[0-3])(?:\\.(?:1?\\d{1,2}|2[0-4]\\d|25[0-5])){2}(?:\\.(?:[0-9]\\d?|1\\d\\d|2[0-4]\\d|25[0-4]))|(?:(?:[a-z\\u00a1-\\uffff0-9]+-?)*[a-z\\u00a1-\\uffff0-9]+)(?:\\.(?:[a-z\\u00a1-\\uffff0-9]+-?)*[a-z\\u00a1-\\uffff0-9]+)*(?:\\.(?:[a-z\\u00a1-\\uffff]{2,})))|localhost)(?::\\d{2,5})?(?:(/|\\?|#)[^\\s]*)?$';
         var url = new RegExp(urlRegex, 'i');
         return url.test(candidate);
+    }
+
+    static async checkUuid(source: string | undefined): Promise<{document: any, resolvedUuid: any, anchor: string | undefined} | undefined> {
+        if (!source) return;
+
+        // @ts-ignore // parseUuid is not defined in the @league-of-foundry-developers/foundry-vtt-types package
+        let resolvedUuid = foundry.utils.parseUuid(source);
+
+        const uuid = resolvedUuid.uuid.split('#')[0];
+        const anchor = resolvedUuid.uuid.split('#')[1];
+
+        const doc = await fromUuid(uuid);
+
+        if(!doc) return;
+        return {document: doc, resolvedUuid: resolvedUuid, anchor: anchor}
     }
 
     /**
@@ -21,9 +39,9 @@ export class LinksHelpers {
      * 
      * This is meant to allow for wikis to be used as sources.
      */
-    static openSourceURL(source: string|undefined) {
+    static openSourceURL(source: string | undefined) {
         if (source === '') {
-            ui.notifications?.error('SR5.SourceFieldEmptyError', {localize: true});
+            ui.notifications?.error('SR5.SourceFieldEmptyError', { localize: true });
         }
 
         window.open(source);
@@ -32,15 +50,15 @@ export class LinksHelpers {
     /**
      * Use the items source field to try matching it against a PDF document and display that within FoundryVTT.
      */
-    static openSourcePDF(source: string|undefined) {
+    static openSourcePDF(source: string | undefined) {
         // Check for pdfpager module hook: https://github.com/farling42/fvtt-pdf-pager
         if (!ui['pdfpager']) {
-            ui.notifications?.warn('SR5.DIALOG.MissingModuleContent', {localize: true});
+            ui.notifications?.warn('SR5.DIALOG.MissingModuleContent', { localize: true });
             return;
         }
 
         if (!source) {
-            ui.notifications?.error('SR5.SourceFieldEmptyError', {localize: true});
+            ui.notifications?.error('SR5.SourceFieldEmptyError', { localize: true });
             return;
         }
 
@@ -50,14 +68,43 @@ export class LinksHelpers {
         ui.pdfpager.openPDFByCode(code, { page: parseInt(page) });
     }
 
+    static async openSourceByUuid({document, resolvedUuid, anchor}: {document: any, resolvedUuid: any, anchor: string | undefined}) {
+
+        if (!document) {
+            ui.notifications?.error('SR5.SourceFieldEmptyError', { localize: true });
+            return;
+        }
+
+        try {             
+
+            if (document instanceof SR5Item || document instanceof SR5Actor || document instanceof JournalEntry) {
+                document.sheet?.render(true);
+                return;
+            // @ts-ignore
+            } else if (document instanceof JournalEntryPage) {
+                document.parent.sheet.render(true, {pageId: document.id, anchor: anchor ? anchor : undefined});
+                    return;
+            } else {
+                ui.notifications?.error(`The document has no associated sheet.`);
+            }
+        } catch (error) {
+            ui.notifications?.error(`Error opening the sheet for UUID: ${resolvedUuid.uuid}`, error);
+        }
+    }
+
     /**
      * Use the items source field and try different means of opening it.
      */
-    static openSource(source: string|undefined) {
+    static async openSource(source: string | undefined) {
         if (LinksHelpers.isURL(source)) {
             LinksHelpers.openSourceURL(source);
         } else {
-            LinksHelpers.openSourcePDF(source);
+            const uuidData = await this.checkUuid(source);
+            if (uuidData) {
+                LinksHelpers.openSourceByUuid(uuidData);
+            } else {
+                LinksHelpers.openSourcePDF(source);
+            }
         }
     }
 }

--- a/src/module/utils/links.ts
+++ b/src/module/utils/links.ts
@@ -22,7 +22,7 @@ export class LinksHelpers {
     static async checkUuid(source: string | undefined): Promise<{document: any, resolvedUuid: any, anchor: string | undefined} | undefined> {
         if (!source) return;
 
-        // @ts-ignore // parseUuid is not defined in the @league-of-foundry-developers/foundry-vtt-types package
+        // @ts-expect-error // parseUuid is not defined in the @league-of-foundry-developers/foundry-vtt-types package
         let resolvedUuid = foundry.utils.parseUuid(source);
 
         const uuid = resolvedUuid.uuid.split('#')[0];
@@ -64,7 +64,7 @@ export class LinksHelpers {
 
         const [code, page] = source.split(' ');
 
-        //@ts-expect-error
+        //@ts-expect-error 
         ui.pdfpager.openPDFByCode(code, { page: parseInt(page) });
     }
 
@@ -80,7 +80,7 @@ export class LinksHelpers {
             if (document instanceof SR5Item || document instanceof SR5Actor || document instanceof JournalEntry) {
                 document.sheet?.render(true);
                 return;
-            // @ts-ignore
+            // @ts-expect-error 
             } else if (document instanceof JournalEntryPage) {
                 document.parent.sheet.render(true, {pageId: document.id, anchor: anchor ? anchor : undefined});
                     return;

--- a/src/module/utils/links.ts
+++ b/src/module/utils/links.ts
@@ -14,9 +14,7 @@ export class LinksHelpers {
      */
     static isURL(candidate: string | undefined): boolean {
         if (!candidate) return false;
-        var urlRegex = '^(?!mailto:)(?:(?:http|https|ftp)://)?(?:\\S+(?::\\S*)?@)?(?:(?:(?:[1-9]\\d?|1\\d\\d|2[01]\\d|22[0-3])(?:\\.(?:1?\\d{1,2}|2[0-4]\\d|25[0-5])){2}(?:\\.(?:[0-9]\\d?|1\\d\\d|2[0-4]\\d|25[0-4]))|(?:(?:[a-z\\u00a1-\\uffff0-9]+-?)*[a-z\\u00a1-\\uffff0-9]+)(?:\\.(?:[a-z\\u00a1-\\uffff0-9]+-?)*[a-z\\u00a1-\\uffff0-9]+)*(?:\\.(?:[a-z\\u00a1-\\uffff]{2,})))|localhost)(?::\\d{2,5})?(?:(/|\\?|#)[^\\s]*)?$';
-        var url = new RegExp(urlRegex, 'i');
-        return url.test(candidate);
+        return candidate.startsWith('http') || candidate.startsWith('https');
     }
 
     static async checkUuid(source: string | undefined): Promise<{document: any, resolvedUuid: any, anchor: string | undefined} | undefined> {

--- a/src/module/utils/links.ts
+++ b/src/module/utils/links.ts
@@ -33,6 +33,7 @@ export class LinksHelpers {
 
         return true;
     }
+
     /**
      * Determine if given string contains a valid uuid pattern.
      * 
@@ -45,12 +46,8 @@ export class LinksHelpers {
     static isUuid(candidate: string | undefined) {
         if (!candidate) return false;
 
-        const parts = candidate.split('.');
-        if (parts.length < 2) return false;
-        const idPart = parts.pop();
-        if (idPart?.length !== 16) return false;
-        
-        return true;
+        // @ts-expect-error // parseUuid is not defined in the @league-of-foundry-developers/foundry-vtt-types package
+        return !!foundry.utils.parseUuid(candidate).collection;
     }
 
     /**

--- a/src/module/utils/sheets.ts
+++ b/src/module/utils/sheets.ts
@@ -97,3 +97,20 @@ export const tagifyFlagsToIds = (effect: SR5ActiveEffect, flag: string): string[
     const tags = JSON.parse(value as string);
     return tagsToIds(tags);
 }
+
+/**
+ * Helper to parse FoundryVTT DropData directly from it's source event
+ *
+ * This is a legacy handler for earlier FoundryVTT versions, however it's good
+ * practice to not trust faulty input and inform about.
+ *
+ * @param event
+ * @returns undefined when an DropData couldn't be parsed from it's JSON.
+ */
+export function parseDropData(event): any | undefined {
+    try {
+        return JSON.parse(event.dataTransfer.getData('text/plain'));
+    } catch (error) {
+        return console.log('Shadowrun 5e | Dropping a document onto an item sheet caused this error', error);
+    }
+}

--- a/src/templates/item/parts/header.html
+++ b/src/templates/item/parts/header.html
@@ -16,8 +16,10 @@
                 <div class="source-button roll open-source" data-tooltip="SR5.OpenSource">
                     {{#if sourceIsURL}}
                     <i class="fas fa-link"></i> 
-                    {{else}}
+                    {{else if sourceIsPDF}}
                     <i class="fas fa-file-pdf"></i> 
+                    {{else if sourceIsUuid}}
+                    <i class="fas fa-file"></i> 
                     {{/if}}
                 </div>
                 <input

--- a/src/templates/item/parts/weapon.html
+++ b/src/templates/item/parts/weapon.html
@@ -21,23 +21,20 @@
             {{localize "SR5.Weapon.AmmoCount"}}
         </div>
         <div class="inputs">
-            <input
-                    size="2"
-                    type="text"
-                    name="system.ammo.current.value"
-                    value="{{system.ammo.current.value}}"
-                    data-dtype="Number"
-                    placeholder="0"
-            />
+            <input size="3" type="text" name="system.ammo.current.value" value="{{system.ammo.current.value}}"
+                data-dtype="Number" placeholder="0" />
             /
-            <input
-                    size="2"
-                    type="text"
-                    name="system.ammo.current.max"
-                    value="{{system.ammo.current.max}}"
-                    data-dtype="Number"
-                    placeholder="{{localize SR5.Max}}"
-            />
+            <input size="3" type="text" name="system.ammo.current.max" value="{{system.ammo.current.max}}"
+                data-dtype="Number" placeholder="{{localize SR5.Max}}" />
+            <select name="change-ammo">
+                {{#select ammunition}}
+                <option value=""></option>
+                {{#each ammunition as |ammo index|}}
+                <option value="{{ammo._id}}" {{#if ammo.system.technology.equipped}}selected{{/if}}>{{localize
+                    name}}
+                </option>
+                {{/each}} {{/select}}
+            </select>
         </div>
     </div>
     {{#if system.category}} {{#ife system.category "range"}}
@@ -46,23 +43,18 @@
             {{localize "SR5.SpareClips"}}
         </div>
         <div class="inputs">
-            <input
-                    size="2"
-                    type="text"
-                    name="system.ammo.spare_clips.value"
-                    value="{{system.ammo.spare_clips.value}}"
-                    data-dtype="Number"
-                    placeholder="0"
-            />
-            /
-            <input
-                    size="2"
-                    type="text"
-                    name="system.ammo.spare_clips.max"
-                    value="{{system.ammo.spare_clips.max}}"
-                    data-dtype="Number"
-                    placeholder="{{localize SR5.Max}}"
-            />
+        <input size="3" type="text" name="system.ammo.spare_clips.value" value="{{system.ammo.spare_clips.value}}"
+            data-dtype="Number" placeholder="0" />
+        /
+        <input size="3" type="text" name="system.ammo.spare_clips.max" value="{{system.ammo.spare_clips.max}}"
+            data-dtype="Number" placeholder="{{localize SR5.Max}}" />
+            <select style="width: auto;" name="change-clip-type">
+                {{#select system.ammo.clip_type}}
+                <option value=""></option>
+                {{#each config.weaponCliptypes as |name type|}}
+                <option value="{{type}}"{{#if system.ammo.clip_type}}selected{{/if}}>{{localize name}}</option>
+                {{/each}} {{/select}}
+            </select>
         </div>
     </div>
     <div class="form-line">
@@ -71,36 +63,20 @@
         </div>
         <div class="inputs">
             <label>
-                {{localize "SR5.Weapon.Mode.SingleShot"}}<input
-                    type="checkbox"
-                    name="system.range.modes.single_shot"
-                    {{checked
-                    system.range.modes.single_shot}}
-                />
+                {{localize "SR5.Weapon.Mode.SingleShot"}}<input type="checkbox" name="system.range.modes.single_shot"
+                    {{checked system.range.modes.single_shot}} />
             </label>
             <label>
-                {{localize "SR5.Weapon.Mode.SemiAuto"}}<input
-                    type="checkbox"
-                    name="system.range.modes.semi_auto"
-                    {{checked
-                    system.range.modes.semi_auto}}
-                />
+                {{localize "SR5.Weapon.Mode.SemiAuto"}}<input type="checkbox" name="system.range.modes.semi_auto"
+                    {{checked system.range.modes.semi_auto}} />
             </label>
             <label>
-                {{localize "SR5.Weapon.Mode.BurstFire"}}<input
-                    type="checkbox"
-                    name="system.range.modes.burst_fire"
-                    {{checked
-                    system.range.modes.burst_fire}}
-                />
+                {{localize "SR5.Weapon.Mode.BurstFire"}}<input type="checkbox" name="system.range.modes.burst_fire"
+                    {{checked system.range.modes.burst_fire}} />
             </label>
             <label>
-                {{localize "SR5.Weapon.Mode.FullAuto"}}<input
-                    type="checkbox"
-                    name="system.range.modes.full_auto"
-                    {{checked
-                    system.range.modes.full_auto}}
-                />
+                {{localize "SR5.Weapon.Mode.FullAuto"}}<input type="checkbox" name="system.range.modes.full_auto"
+                    {{checked system.range.modes.full_auto}} />
             </label>
         </div>
     </div>
@@ -110,54 +86,25 @@
             {{localize "SR5.Weapon.Range.Ranges"}}
         </div>
         <div class="inputs ranges">
-            <select
-                name="system.range.ranges.category"
-                class="select-ranged-range-category"
-            >
+            <select name="system.range.ranges.category" class="select-ranged-range-category">
                 {{#each config.weaponRangeCategories as |val key|}}
-                <option value="{{key}}"{{#ife ../system.range.ranges.category key}}selected="selected"{{/ife}}>{{localize val.label}}</option>
+                <option value="{{key}}" {{#ife ../system.range.ranges.category key}}selected="selected" {{/ife}}>
+                    {{localize val.label}}</option>
                 {{/each}}
             </select>
-            <input
-                size="3"
-                type="text"
-                name="system.range.ranges.short"
-                value="{{system.range.ranges.short}}"
-                data-dtype="Number"
-                {{#if this.isUsingRangeCategory}} disabled {{/if}}
-            />
+            <input size="3" type="text" name="system.range.ranges.short" value="{{system.range.ranges.short}}"
+                data-dtype="Number" {{#if this.isUsingRangeCategory}} disabled {{/if}} />
             /
-            <input
-                size="3"
-                type="text"
-                name="system.range.ranges.medium"
-                value="{{system.range.ranges.medium}}"
-                data-dtype="Number"
-                {{#if this.isUsingRangeCategory}} disabled {{/if}}
-            />
+            <input size="3" type="text" name="system.range.ranges.medium" value="{{system.range.ranges.medium}}"
+                data-dtype="Number" {{#if this.isUsingRangeCategory}} disabled {{/if}} />
             /
-            <input
-                size="3"
-                type="text"
-                name="system.range.ranges.long"
-                value="{{system.range.ranges.long}}"
-                data-dtype="Number"
-                {{#if this.isUsingRangeCategory}} disabled {{/if}}
-            />
+            <input size="3" type="text" name="system.range.ranges.long" value="{{system.range.ranges.long}}"
+                data-dtype="Number" {{#if this.isUsingRangeCategory}} disabled {{/if}} />
             /
-            <input
-                size="3"
-                type="text"
-                name="system.range.ranges.extreme"
-                value="{{system.range.ranges.extreme}}"
-                data-dtype="Number"
-                {{#if this.isUsingRangeCategory}} disabled {{/if}}
-            />
+            <input size="3" type="text" name="system.range.ranges.extreme" value="{{system.range.ranges.extreme}}"
+                data-dtype="Number" {{#if this.isUsingRangeCategory}} disabled {{/if}} />
             <i class="fas fa-times"></i>
-            <select
-                name="system.range.ranges.attribute"
-                {{#if this.isUsingRangeCategory}} disabled {{/if}}
-            >
+            <select name="system.range.ranges.attribute" {{#if this.isUsingRangeCategory}} disabled {{/if}}>
                 {{#select system.range.ranges.attribute}}
                 <option value=""></option>
                 {{#each config.attributes as |name type|}}
@@ -171,14 +118,8 @@
             {{localize "SR5.RecoilCompensation"}}
         </div>
         <div class="inputs">
-            <input
-                type="text"
-                size="2"
-                name="system.range.rc.base"
-                value="{{system.range.rc.base}}"
-                data-dtype="Number"
-                placeholder="1"
-            />
+            <input type="text" size="2" name="system.range.rc.base" value="{{system.range.rc.base}}" data-dtype="Number"
+                placeholder="1" />
         </div>
     </div>
     {{/ife}} {{#ife system.category "thrown"}}
@@ -187,54 +128,25 @@
             {{localize "SR5.Weapon.Range.Ranges"}}
         </div>
         <div class="inputs ranges">
-            <select
-                name="system.thrown.ranges.category"
-                class="select-thrown-range-category"
-            >
+            <select name="system.thrown.ranges.category" class="select-thrown-range-category">
                 {{#each config.weaponRangeCategories as |val key|}}
-                <option value="{{key}}"{{#ife ../system.thrown.ranges.category key}}selected="selected"{{/ife}}>{{localize val.label}}</option>
+                <option value="{{key}}" {{#ife ../system.thrown.ranges.category key}}selected="selected" {{/ife}}>
+                    {{localize val.label}}</option>
                 {{/each}}
             </select>
-            <input
-                size="3"
-                type="text"
-                name="system.thrown.ranges.short"
-                value="{{system.thrown.ranges.short}}"
-                data-dtype="Number"
-                {{#if this.isUsingRangeCategory}} disabled {{/if}}
-            />
+            <input size="3" type="text" name="system.thrown.ranges.short" value="{{system.thrown.ranges.short}}"
+                data-dtype="Number" {{#if this.isUsingRangeCategory}} disabled {{/if}} />
             /
-            <input
-                size="3"
-                type="text"
-                name="system.thrown.ranges.medium"
-                value="{{system.thrown.ranges.medium}}"
-                data-dtype="Number"
-                {{#if this.isUsingRangeCategory}} disabled {{/if}}
-            />
+            <input size="3" type="text" name="system.thrown.ranges.medium" value="{{system.thrown.ranges.medium}}"
+                data-dtype="Number" {{#if this.isUsingRangeCategory}} disabled {{/if}} />
             /
-            <input
-                size="3"
-                type="text"
-                name="system.thrown.ranges.long"
-                value="{{system.thrown.ranges.long}}"
-                data-dtype="Number"
-                {{#if this.isUsingRangeCategory}} disabled {{/if}}
-            />
+            <input size="3" type="text" name="system.thrown.ranges.long" value="{{system.thrown.ranges.long}}"
+                data-dtype="Number" {{#if this.isUsingRangeCategory}} disabled {{/if}} />
             /
-            <input
-                size="3"
-                type="text"
-                name="system.thrown.ranges.extreme"
-                value="{{system.thrown.ranges.extreme}}"
-                data-dtype="Number"
-                {{#if this.isUsingRangeCategory}} disabled {{/if}}
-            />
+            <input size="3" type="text" name="system.thrown.ranges.extreme" value="{{system.thrown.ranges.extreme}}"
+                data-dtype="Number" {{#if this.isUsingRangeCategory}} disabled {{/if}} />
             <i class="fas fa-times"></i>
-            <select
-                name="system.thrown.ranges.attribute"
-                {{#if this.isUsingRangeCategory}} disabled {{/if}}
-            >
+            <select name="system.thrown.ranges.attribute" {{#if this.isUsingRangeCategory}} disabled {{/if}}>
                 {{#select system.thrown.ranges.attribute}}
                 <option value=""></option>
                 {{#each config.attributes as |name type|}}
@@ -249,14 +161,8 @@
             {{localize "SR5.Weapon.Reach"}}
         </div>
         <div class="inputs">
-            <input
-                type="text"
-                size="2"
-                name="system.melee.reach"
-                value="{{system.melee.reach}}"
-                data-dtype="Number"
-                placeholder="1"
-            />
+            <input type="text" size="2" name="system.melee.reach" value="{{system.melee.reach}}" data-dtype="Number"
+                placeholder="1" />
         </div>
     </div>
     {{/ife}} {{#ife system.category "thrown"}}
@@ -265,14 +171,8 @@
             {{localize "SR5.Radius"}}
         </div>
         <div class="inputs">
-            <input
-                type="text"
-                size="4"
-                name="system.thrown.blast.radius"
-                value="{{system.thrown.blast.radius}}"
-                data-dtype="Number"
-                placeholder="1"
-            />
+            <input type="text" size="4" name="system.thrown.blast.radius" value="{{system.thrown.blast.radius}}"
+                data-dtype="Number" placeholder="1" />
             m
         </div>
     </div>
@@ -281,14 +181,8 @@
             {{localize "SR5.Dropoff"}}
         </div>
         <div class="inputs">
-            <input
-                size="3"
-                type="text"
-                name="system.thrown.blast.dropoff"
-                value="{{system.thrown.blast.dropoff}}"
-                data-dtype="Number"
-                placeholder="-1"
-            />
+            <input size="3" type="text" name="system.thrown.blast.dropoff" value="{{system.thrown.blast.dropoff}}"
+                data-dtype="Number" placeholder="-1" />
             /m
         </div>
     </div>

--- a/src/unittests/sr5.RangedWeapon.spec.ts
+++ b/src/unittests/sr5.RangedWeapon.spec.ts
@@ -56,14 +56,14 @@ export const shadowrunSR5RangedWeaponRules = (context: QuenchBatchContext) => {
         it('Reload weapon causes reduction in available clips', async () => {
             const item = await testItem.create({type: 'weapon', system: {category: 'ranged', ammo: {current: {value: 0, max: 30}, spare_clips: {value: 1, max: 1}}}}) as SR5Item;
             assert.strictEqual(item.system.ammo?.spare_clips.value, 1);
-            await item.reloadAmmo();
+            await item.reloadAmmo(true);
             assert.strictEqual(item.system.ammo?.spare_clips.value, 0);
         });
 
         it('Reloads weapon fully when no ammo is used', async () => {
             const item = await testItem.create({type: 'weapon', system: {category: 'ranged', ammo: {current: {value: 0, max: 30}}}}) as SR5Item;
             assert.strictEqual(item.system.ammo?.current.value, 0);
-            await item.reloadAmmo();
+            await item.reloadAmmo(true);
             assert.strictEqual(item.system.ammo?.current.value, item.system.ammo?.current.max);
         });
 
@@ -74,7 +74,7 @@ export const shadowrunSR5RangedWeaponRules = (context: QuenchBatchContext) => {
             const ammo = item.getEquippedAmmo();
             assert.strictEqual(item.system.ammo?.current.value, 15);
             assert.strictEqual(ammo.system.technology?.quantity, 30);
-            await item.reloadAmmo();
+            await item.reloadAmmo(true);
             assert.strictEqual(item.system.ammo?.current.value, item.system.ammo?.current.max);
             assert.strictEqual(ammo.system.technology?.quantity, 15);
         });
@@ -86,7 +86,7 @@ export const shadowrunSR5RangedWeaponRules = (context: QuenchBatchContext) => {
             const ammo = item.getEquippedAmmo();
             assert.strictEqual(item.system.ammo?.current.value, 15);
             assert.strictEqual(ammo.system.technology?.quantity, 0);
-            await item.reloadAmmo();
+            await item.reloadAmmo(true);
             assert.strictEqual(item.system.ammo?.current.value, 15);
             assert.strictEqual(ammo.system.technology?.quantity, 0);
         });
@@ -98,7 +98,7 @@ export const shadowrunSR5RangedWeaponRules = (context: QuenchBatchContext) => {
             const ammo = item.getEquippedAmmo();
             assert.strictEqual(item.system.ammo?.current.value, 15);
             assert.strictEqual(ammo.system.technology?.quantity, 10);
-            await item.reloadAmmo();
+            await item.reloadAmmo(true);
             assert.strictEqual(item.system.ammo?.current.value, 25);
             assert.strictEqual(ammo.system.technology?.quantity, 0);
         });

--- a/template.json
+++ b/template.json
@@ -1209,7 +1209,9 @@
                     "current": {
                         "value": 0,
                         "max": 0
-                    }
+                    },
+                    "clip_type": "",
+                    "partial_reload_value": 0
                 },
                 "range": {
                     "category": "",

--- a/template.json
+++ b/template.json
@@ -1211,7 +1211,7 @@
                         "max": 0
                     },
                     "clip_type": "",
-                    "partial_reload_value": 0
+                    "partial_reload_value": -1
                 },
                 "range": {
                     "category": "",


### PR DESCRIPTION
I have put two dropdowns in the weapon action tab.

An ammunition bar that reflects which ammunition is currently equipped and which can also be used to equip ammunition.

For ranged weapons there is also a dropdown for clip types. Here you can set which clip type you use with the weapon. Several different possible types are so rare that the code effort is not worth it, in my opinion.

In the inventory, reloading is now divided into up to two buttons. One for reloading to full weapon capacity and one for partial reloading. If a clip type with a (complex) action can only be reloaded x rounds, this number is displayed and only this number is reloaded when clicked. If (during a fight, I don't assume that how fast you get rounds into a spare clip or a drum is relevant enough) it is a clip type that can only be fully reloaded, the partial reload button is not displayed.

I've tested it and it should all work, I just don't know if I've ignored any best practices. So it would be good if @taMiF  would take a critical look at it.