### PR TITLE
[Feature] Add ability to Drag and Drop Active Effects

### DIFF
--- a/public/locale/en/config.json
+++ b/public/locale/en/config.json
@@ -104,6 +104,7 @@
             "TargetedActor": "Targeted Actor",
             "TestItem": "Test via Item"
         },
+        "CannotAddTestViaItemToActor": "Cannot add an Active Effect of type 'Test via Item' to an Actor",
         "Modes": {
             "Modify": "Modify"
         },

--- a/src/module/actor/sheets/SR5BaseActorSheet.ts
+++ b/src/module/actor/sheets/SR5BaseActorSheet.ts
@@ -511,13 +511,14 @@ export class SR5BaseActorSheet extends ActorSheet {
         if (data !== undefined) {
             if (data.type === 'ActiveEffect' && data.actorId !== this.actor.id) {
                 const effect = data.data;
-                console.log('effect', effect);
                 const applyTo = effect.flags.shadowrun5e.applyTo as EffectApplyTo;
                 // if the effect is just supposed to apply to the item's test, it won't work on an actor
                 if (applyTo === 'test_item') {
                     ui.notifications?.warn(game.i18n.localize('SR5.ActiveEffect.CannotAddTestViaItemToActor'));
                     return;
                 }
+                // delete the id so a new one is generated
+                delete effect._id;
                 await this.actor.createEmbeddedDocuments('ActiveEffect', [effect]);
                 // don't process anything else since we handled the drop
                 return;

--- a/src/module/actor/sheets/SR5BaseActorSheet.ts
+++ b/src/module/actor/sheets/SR5BaseActorSheet.ts
@@ -460,14 +460,7 @@ export class SR5BaseActorSheet extends ActorSheet {
                 let effect = this.actor.effects.get(effectId);
                 if (!effect) {
                     // check to see if it belongs to an item we own
-                    effect = this.actor.items.reduce((effect: SR5ActiveEffect | undefined, item) => {
-                        // if we found the effect we can stop searching for it
-                        if (effect) {
-                            return effect;
-                        }
-                        // if we haven't found it yet, check our items
-                        return item.effects.get(effectId);
-                    }, undefined);
+                    effect = await fromUuid(effectId) as SR5ActiveEffect | undefined;
                 }
                 if (effect) {
                     // Prepare data transfer

--- a/src/module/apps/gmtools/OverwatchScoreTracker.js
+++ b/src/module/apps/gmtools/OverwatchScoreTracker.js
@@ -147,17 +147,13 @@ export class OverwatchScoreTracker extends Application {
         this.render();
     }
 
-    _rollFor15Minutes(event) {
+    async _rollFor15Minutes(event) {
         event.preventDefault();
         const actor = this._getActorFromEvent(event);
         if (actor) {
             //  use static value so it can be modified in modules
             const roll = new Roll(OverwatchScoreTracker.MatrixOverwatchDiceCount);
-            roll.evaluate({async: false});
-
-            // use GM Roll Mode so players don't see
-            // const rollMode = CONFIG.Dice.rollModes.gmroll;
-            // roll.toMessage({ rollMode });
+            await roll.evaluate();
 
             if (roll.total) {
                 const os = actor.getOverwatchScore();

--- a/src/module/item/SR5ItemSheet.ts
+++ b/src/module/item/SR5ItemSheet.ts
@@ -357,6 +357,8 @@ export class SR5ItemSheet extends ItemSheet {
         if (element) {
             // Create drag data object to use
             const dragData = {
+                actor: this.item.actor,
+                actorId: this.item.actor?.id,
                 itemId: this.item.id,
                 type: '',
                 data: {}
@@ -405,7 +407,6 @@ export class SR5ItemSheet extends ItemSheet {
             delete effect._id;
             // add this to the embedded ActiveEffect documents
             await this.item.createEmbeddedDocuments('ActiveEffect', [effect]);
-            this.render();
             return;
         }
 

--- a/src/module/types/item/Quality.ts
+++ b/src/module/types/item/Quality.ts
@@ -11,5 +11,6 @@ declare namespace Shadowrun {
     export interface QualityPartData {
         type: 'positive' | 'negative' | '';
         rating: number;
+        karma: number;
     }
 }

--- a/src/templates/actor/tabs/EffectsTab.html
+++ b/src/templates/actor/tabs/EffectsTab.html
@@ -34,7 +34,7 @@
         {{> 'systems/shadowrun5e/dist/templates/common/List/ListItem.html'
             img=(firstDefined this.img this.icon)
             name=this.sheetName
-            itemId=this.uuid
+            itemId=this.id
             itemType='ActiveEffect'
             icons=(ItemEffectIcons this)
             rightSide=(EffectRightSide this)

--- a/src/templates/actor/tabs/EffectsTab.html
+++ b/src/templates/actor/tabs/EffectsTab.html
@@ -14,6 +14,7 @@
             img=(firstDefined this.img this.icon)
             name=this.name
             itemId=this.id
+            itemType='ActiveEffect'
             icons=(EffectIcons this)
             rightSide=(EffectRightSide this)
             hasDesc=false
@@ -34,6 +35,7 @@
             img=(firstDefined this.img this.icon)
             name=this.sheetName
             itemId=this.uuid
+            itemType='ActiveEffect'
             icons=(ItemEffectIcons this)
             rightSide=(EffectRightSide this)
             hasDesc=false

--- a/src/templates/actor/tabs/EffectsTab.html
+++ b/src/templates/actor/tabs/EffectsTab.html
@@ -34,7 +34,7 @@
         {{> 'systems/shadowrun5e/dist/templates/common/List/ListItem.html'
             img=(firstDefined this.img this.icon)
             name=this.sheetName
-            itemId=this.id
+            itemId=this.uuid
             itemType='ActiveEffect'
             icons=(ItemEffectIcons this)
             rightSide=(EffectRightSide this)

--- a/src/templates/item/quality.html
+++ b/src/templates/item/quality.html
@@ -31,6 +31,19 @@
                                 placeholder="0"
                             />
                         </div>
+                        <div class="flexrow nowrap">
+                            <label>{{localize "SR5.Karma"}}</label>
+                            <input
+                                class="display"
+                                type="text"
+                                size="2"
+                                maxlength="3"
+                                name="system.karma"
+                                value="{{system.karma}}"
+                                data-dtype="Number"
+                                placeholder="0"
+                            />
+                        </div>
                     </div>
                 </div>
                 {{> "systems/shadowrun5e/dist/templates/item/parts/description.html"}}


### PR DESCRIPTION
adds the ability to drag and drop effects between actors and items. Effects displaying for items on the actor had to be tweaked but it looks to work. 
The only limitation I did with the copying is "test via item" cannot be added to an Actor. 
This also includes a fix for the +15 min Overwatch score bug