### PR TITLE
[FEATURE] Effect storage via macro

### DIFF
--- a/public/locale/de/config.json
+++ b/public/locale/de/config.json
@@ -98,6 +98,8 @@
             "TargetedActor": "Anvisierten Akteur",
             "TestItem": "Probe aus Item"
         },
+        "CannotAddTestViaItemToActor": "Es kann kein Effekt vom Typ 'Probe aus Item' zu einem Akteur hinzugefügt werden.",
+        "CopyEffectFromMacro": "Du musst das Makro per Drag and Drop aus dem Makro-Ordner oder einem Kompendium auf einen Akteur oder ein Item ziehen.",
         "Modes": {
             "Modify": "Modifizieren"
         },

--- a/public/locale/en/config.json
+++ b/public/locale/en/config.json
@@ -105,6 +105,7 @@
             "TestItem": "Test via Item"
         },
         "CannotAddTestViaItemToActor": "Cannot add an Active Effect of type 'Test via Item' to an Actor",
+        "CopyEffectFromMacro": "You need to drag and drop the macro from the macro folder or a compendium onto an actor or item.",
         "Modes": {
             "Modify": "Modify"
         },

--- a/src/module/hooks.ts
+++ b/src/module/hooks.ts
@@ -2,61 +2,61 @@ import { CompileSpriteTest } from './tests/CompileSpriteTest';
 import { OpposedSummonSpiritTest } from './tests/OpposedSummonSpiritTest';
 import { OpposedRitualTest } from './tests/OpposedRitualTest';
 import { RitualSpellcastingTest } from './tests/RitualSpellcastingTest';
-import {SR5} from './config';
-import {Migrator} from './migrator/Migrator';
-import {registerSystemSettings} from './settings';
-import {FLAGS, SYSTEM_NAME, SYSTEM_SOCKET} from './constants';
-import {SR5Actor} from './actor/SR5Actor';
-import {SR5Item} from './item/SR5Item';
-import {SR5ItemSheet} from './item/SR5ItemSheet';
-import {SR5Token} from './token/SR5Token';
-import {SR5ActiveEffect} from "./effect/SR5ActiveEffect";
-import {_combatantGetInitiativeFormula, SR5Combat} from './combat/SR5Combat';
-import {HandlebarManager} from './handlebars/HandlebarManager';
+import { SR5 } from './config';
+import { Migrator } from './migrator/Migrator';
+import { registerSystemSettings } from './settings';
+import { FLAGS, SYSTEM_NAME, SYSTEM_SOCKET } from './constants';
+import { SR5Actor } from './actor/SR5Actor';
+import { SR5Item } from './item/SR5Item';
+import { SR5ItemSheet } from './item/SR5ItemSheet';
+import { SR5Token } from './token/SR5Token';
+import { SR5ActiveEffect } from "./effect/SR5ActiveEffect";
+import { _combatantGetInitiativeFormula, SR5Combat } from './combat/SR5Combat';
+import { HandlebarManager } from './handlebars/HandlebarManager';
 
-import {OverwatchScoreTracker} from './apps/gmtools/OverwatchScoreTracker';
-import {Import} from './apps/itemImport/apps/import-form';
-import {ChangelogApplication} from "./apps/ChangelogApplication";
+import { OverwatchScoreTracker } from './apps/gmtools/OverwatchScoreTracker';
+import { Import } from './apps/itemImport/apps/import-form';
+import { ChangelogApplication } from "./apps/ChangelogApplication";
 import { SituationModifiersApplication } from './apps/SituationModifiersApplication';
-import {SR5ICActorSheet} from "./actor/sheets/SR5ICActorSheet";
-import {SR5ActiveEffectConfig} from "./effect/SR5ActiveEffectConfig";
-import {SR5VehicleActorSheet} from "./actor/sheets/SR5VehicleActorSheet";
-import {SR5CharacterSheet} from "./actor/sheets/SR5CharacterSheet";
-import {SR5SpiritActorSheet} from "./actor/sheets/SR5SpiritActorSheet";
-import {SR5SpriteActorSheet} from "./actor/sheets/SR5SpriteActorSheet";
+import { SR5ICActorSheet } from "./actor/sheets/SR5ICActorSheet";
+import { SR5ActiveEffectConfig } from "./effect/SR5ActiveEffectConfig";
+import { SR5VehicleActorSheet } from "./actor/sheets/SR5VehicleActorSheet";
+import { SR5CharacterSheet } from "./actor/sheets/SR5CharacterSheet";
+import { SR5SpiritActorSheet } from "./actor/sheets/SR5SpiritActorSheet";
+import { SR5SpriteActorSheet } from "./actor/sheets/SR5SpriteActorSheet";
 
-import {SR5Roll} from "./rolls/SR5Roll";
-import {SuccessTest} from "./tests/SuccessTest";
-import {TeamworkTest} from "./actor/flows/TeamworkFlow";
-import {OpposedTest} from "./tests/OpposedTest";
-import {PhysicalDefenseTest} from "./tests/PhysicalDefenseTest";
-import {RangedAttackTest} from "./tests/RangedAttackTest";
-import {PhysicalResistTest} from "./tests/PhysicalResistTest";
-import {MeleeAttackTest} from "./tests/MeleeAttackTest";
-import {SpellCastingTest} from "./tests/SpellCastingTest";
-import {DrainTest} from "./tests/DrainTest";
-import {TestCreator} from "./tests/TestCreator";
-import {CombatSpellDefenseTest} from "./tests/CombatSpellDefenseTest";
-import {ComplexFormTest} from "./tests/ComplexFormTest";
-import {AttributeOnlyTest} from "./tests/AttributeOnlyTest";
-import {NaturalRecoveryStunTest} from "./tests/NaturalRecoveryStunTest";
-import {NaturalRecoveryPhysicalTest} from "./tests/NaturalRecoveryPhysicalTest";
-import {FadeTest} from "./tests/FadeTest";
-import {ThrownAttackTest} from "./tests/ThrownAttackTest";
-import {PilotVehicleTest} from "./tests/PilotVehicleTest";
-import {DronePerceptionTest} from "./tests/DronePerceptionTest";
-import {DroneInfiltrationTest} from "./tests/DroneInfiltrationTest";
+import { SR5Roll } from "./rolls/SR5Roll";
+import { SuccessTest } from "./tests/SuccessTest";
+import { TeamworkTest } from "./actor/flows/TeamworkFlow";
+import { OpposedTest } from "./tests/OpposedTest";
+import { PhysicalDefenseTest } from "./tests/PhysicalDefenseTest";
+import { RangedAttackTest } from "./tests/RangedAttackTest";
+import { PhysicalResistTest } from "./tests/PhysicalResistTest";
+import { MeleeAttackTest } from "./tests/MeleeAttackTest";
+import { SpellCastingTest } from "./tests/SpellCastingTest";
+import { DrainTest } from "./tests/DrainTest";
+import { TestCreator } from "./tests/TestCreator";
+import { CombatSpellDefenseTest } from "./tests/CombatSpellDefenseTest";
+import { ComplexFormTest } from "./tests/ComplexFormTest";
+import { AttributeOnlyTest } from "./tests/AttributeOnlyTest";
+import { NaturalRecoveryStunTest } from "./tests/NaturalRecoveryStunTest";
+import { NaturalRecoveryPhysicalTest } from "./tests/NaturalRecoveryPhysicalTest";
+import { FadeTest } from "./tests/FadeTest";
+import { ThrownAttackTest } from "./tests/ThrownAttackTest";
+import { PilotVehicleTest } from "./tests/PilotVehicleTest";
+import { DronePerceptionTest } from "./tests/DronePerceptionTest";
+import { DroneInfiltrationTest } from "./tests/DroneInfiltrationTest";
 import { SuppressionDefenseTest } from './tests/SuppressionDefenseTest';
 import { SummonSpiritTest } from './tests/SummonSpiritTest';
 
 import { quenchRegister } from '../unittests/quench';
-import { createItemMacro, createSkillMacro, rollItemMacro, rollSkillMacro } from './macros';
+import { createItemMacro, createSkillMacro, createEffectMacro, rollItemMacro, rollSkillMacro, copyEffectMacro } from './macros';
 
 import { NetworkDeviceFlow } from './item/flows/NetworkDeviceFlow';
 import { registerSystemKeybindings } from './keybindings';
 import { SkillTest } from './tests/SkillTest';
 
-import {canvasInit} from './canvas';
+import { canvasInit } from './canvas';
 import { ActionFollowupFlow } from './item/flows/ActionFollowupFlow';
 import { OpposedCompileSpriteTest } from './tests/OpposedCompileSpriteTest';
 import { SR5CallInActionSheet } from './item/sheets/SR5CallInActionSheet';
@@ -128,6 +128,7 @@ ___________________
              */
             rollItemMacro,
             rollSkillMacro,
+            copyEffectMacro,
             /**
              * Should you only really need dice handling, use this. If you need more complex testing behaviour,
              * check the Test implementations.
@@ -254,11 +255,11 @@ ___________________
         // Setting to false, will NOT duplicate item effects on actors. Instead items will be traversed for their effects.
         // Setting to true, will duplicate item effects on actors. Only effects on actors will be traversed.
         CONFIG.ActiveEffect.legacyTransferral = false;
-        
+
         CONFIG.Token.objectClass = SR5Token;
 
         // Register initiative directly (outside of system.json) as DnD5e does it.
-        CONFIG.Combat.initiative.formula =  "@initiative.current.base.value[Base] + @initiative.current.dice.text[Dice] - @wounds.value[Wounds]";
+        CONFIG.Combat.initiative.formula = "@initiative.current.base.value[Base] + @initiative.current.dice.text[Dice] - @wounds.value[Wounds]";
         // @ts-expect-error
         Combatant.prototype._getInitiativeFormula = _combatantGetInitiativeFormula;
 
@@ -341,7 +342,7 @@ ___________________
                 await Migrator.InitWorldForMigration();
                 return;
             }
-            
+
             // On populated worlds, try migrating
             await Migrator.BeginMigration();
 
@@ -376,6 +377,9 @@ ___________________
         switch (dropData.type) {
             case 'Item':
                 createItemMacro(dropData, slot);
+                return false;
+            case 'ActiveEffect':
+                createEffectMacro(dropData, slot);
                 return false;
             case 'Skill':
                 createSkillMacro(dropData.data, slot);
@@ -417,10 +421,10 @@ ___________________
     }
 
     static renderItemDirectory(app: Application, html: JQuery) {
-        if(!game.user?.isGM){
-            return 
+        if (!game.user?.isGM) {
+            return
         }
-        
+
         const button = $('<button class="sr5 flex0">Import Chummer Data</button>');
         html.find('footer').before(button);
         button.on('click', (event) => {
@@ -519,6 +523,6 @@ ___________________
     }
 
     static async configureTextEnrichers() {
-       await JournalEnrichers.setEnrichers();
+        await JournalEnrichers.setEnrichers();
     }
 }

--- a/src/module/item/SR5ItemSheet.ts
+++ b/src/module/item/SR5ItemSheet.ts
@@ -410,6 +410,25 @@ export class SR5ItemSheet extends ItemSheet {
             return;
         }
 
+        if (data.type === 'Macro') {
+            const effectMacro = await fromUuid(data.uuid) as Macro;
+            if (!effectMacro) return;
+            const command = effectMacro.toJSON().command
+            const macroStart = "game.shadowrun5e.copyEffectMacro(";
+            const macroEnd = ");";
+            const startIndex = command.indexOf(macroStart);
+            const endIndex = command.lastIndexOf(macroEnd);
+            if (startIndex !== -1 && endIndex !== -1) {
+                const effectString = command.substring(startIndex + macroStart.length, endIndex).trim();
+                try {
+                    await this.item.createEmbeddedDocuments('ActiveEffect', [JSON.parse(effectString)]);
+                } catch (e) {
+                    console.log(e);
+                    return;
+                }
+            }
+        }
+
         // Add items to a weapons modification / ammo
         if (this.item.isWeapon && data.type === 'Item') {
             let item;


### PR DESCRIPTION
You can drag effects from actors and items into the hotbar to create a macro.

The macro can be dragged from the macro folder or a compendium back into an actor or item to copy the effect there. Unfortunately, you cannot drag it from the hotbar itself. 

If you just run the macro, you get a message that you have to use drag & drop.

This also solves issue #1189.