### PR TITLE
[CICD] Support for version and compatibility 

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,7 +20,7 @@ jobs:
                   DOWNLOAD: https://github.com/${{github.repository}}/releases/download/${{github.event.release.tag_name}}/shadowrun5e.zip
                   VERSION: ${{github.event.release.tag_name}}
               run: |
-                    apt-get install moreutils
+                    sudo apt-get install moreutils
                     jq --arg url $URL '.url=$url' system.json | sponge system.json
                     jq --arg manifest $MANIFEST '.manifest=$manifest' system.json | sponge system.json
                     jq --arg download $DOWNLOAD '.download=$download' system.json | sponge system.json

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,7 +23,10 @@ jobs:
                     jq --arg version $VERSION '.version=$version' system.json > system.json
 
             - name: Read System manifest for later use
-              run: echo "MANIFEST_JSON=$(jq -c . < system.json)" >> $GITHUB_ENV
+              run: |
+                    cat system.json
+                    echo "MANIFEST_JSON=$(jq -c . < system.json)" >> $GITHUB_ENV
+                    echo $GITHUB_ENV
 
             - name: Build and package release artifacts
               run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,12 +26,6 @@ jobs:
                     jq --arg download $DOWNLOAD '.download=$download' system.json | sponge system.json
                     jq --arg version $VERSION '.version=$version' system.json | sponge system.json
 
-            - name: Read file contents
-              id: read_file
-              uses: andstor/file-reader-action@v1
-              with:
-                path: "system.json"
-
             - name: Read System manifest for later use
               run: |
                     cat system.json
@@ -68,4 +62,4 @@ jobs:
                   method: 'POST'
                   contentType: 'application/json'
                   customHeaders: '{"Authorization": "${{ secrets.FVTT_PACKAGE_RELEASE_TOKEN }}"}'
-                  data: '{"id": "shadowrun5e", "dry-run": true, "release":{"version":"v${{github.event.release.tag_name}}","manifest":"https://github.com/SR5-FoundryVTT/SR5-FoundryVTT/releases/latest/download/system.json","notes":"https://github.com/smilligan93/SR5-FoundryVTT/releases/tag/${{github.event.release.tag_name}}","compatibility":{"minimum":"${{ env.MINIMUM }}","verified":"${{ env.VERIFIED }}","maximum": "${{ env.MAXIMUM }}"}}}'
+                  data: '{"id": "shadowrun5e", "release":{"version":"v${{github.event.release.tag_name}}","manifest":"https://github.com/SR5-FoundryVTT/SR5-FoundryVTT/releases/latest/download/system.json","notes":"https://github.com/smilligan93/SR5-FoundryVTT/releases/tag/${{github.event.release.tag_name}}","compatibility":{"minimum":"${{ env.MINIMUM }}","verified":"${{ env.VERIFIED }}","maximum":"${{ env.MAXIMUM }}"}}}'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,23 +11,28 @@ jobs:
             - uses: actions/checkout@v4
 
             - name: Modify System Manifest With Release-Specific Values
-              id: sub_manifest_link_version
-              uses: cschleiden/replace-tokens@v1
-              with:
-                  files: 'system.json'
               env:
                   URL: https://github.com/${{github.repository}}
                   MANIFEST: https://github.com/${{github.repository}}/releases/latest/download/system.json
                   DOWNLOAD: https://github.com/${{github.repository}}/releases/download/${{github.event.release.tag_name}}/shadowrun5e.zip
+                  VERSION: ${{github.event.release.tag_name}}
+              run: |
+                    jq --arg url $URL '.url=$url' system.json > system.json
+                    jq --arg manifest $MANIFEST '.manifest=$manifest' system.json > system.json
+                    jq --arg download $DOWNLOAD '.download=$download' system.json > system.json
+                    jq --arg version $VERSION '.version=$version' system.json > system.json
 
-            - run: |
+            - name: Read System manifest for later use
+              run: echo "MANIFEST_JSON=$(jq -c . < system.json)" >> $GITHUB_ENV
+
+            - name: Build and package release artifacts
+              run: |
                   npm ci
                   gulp build
                   npm run build:db
                   zip -r ./shadowrun5e.zip system.json template.json LICENSE README.md README-DEV.md dist/ packs/ --exclude "packs/_source/*"
 
             - name: Update Release with Files
-              id: create_version_release
               uses: ncipollo/release-action@v1
               with:
                   makeLatest: false # Must be false, to allow test releases using this workflow.
@@ -42,9 +47,12 @@ jobs:
 
             - name: Deploy Release
               uses: fjogeleit/http-request-action@v1
+              env:
+                  MINIMUM: ${{ fromJson(env.MANIFEST_JSON).compatibility.minimum }}
+                  VERIFIED: ${{ fromJson(env.MANIFEST_JSON).compatibility.verified }}
               with:
                   url: 'https://api.foundryvtt.com/_api/packages/release_version'
                   method: 'POST'
                   contentType: 'application/json'
                   customHeaders: '{"Authorization": "${{ secrets.FVTT_PACKAGE_RELEASE_TOKEN }}"}'
-                  data: '{"id": "shadowrun5e", "release":{"version":"v${{github.event.release.tag_name}}","manifest":"https://github.com/SR5-FoundryVTT/SR5-FoundryVTT/releases/latest/download/system.json","notes":"https://github.com/smilligan93/SR5-FoundryVTT/releases/tag/${{github.event.release.tag_name}}","compatibility":{"minimum":"11","verified":"12","maximum":"12"}}}'
+                  data: '{"id": "shadowrun5e", "dry-run": true, "release":{"version":"v${{github.event.release.tag_name}}","manifest":"https://github.com/SR5-FoundryVTT/SR5-FoundryVTT/releases/latest/download/system.json","notes":"https://github.com/smilligan93/SR5-FoundryVTT/releases/tag/${{github.event.release.tag_name}}","compatibility":{"minimum":"$MINIMUM","verified":"$VERIFIED","maximum": 12}}}'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,14 +10,8 @@ jobs:
         steps:
             - uses: actions/checkout@v4
 
-            - name: Read file contents
-              id: read_file_1
-              uses: andstor/file-reader-action@v1
-              with:
-                path: "system.json"
-
-            - name: Show manifest
-              run: echo "${{ steps.read_file_1.outputs.content }}"
+            - name: Install prerequisites
+              run: sudo apt-get install moreutils
 
             - name: Modify System Manifest With Release-Specific Values
               env:
@@ -26,10 +20,11 @@ jobs:
                   DOWNLOAD: https://github.com/${{github.repository}}/releases/download/${{github.event.release.tag_name}}/shadowrun5e.zip
                   VERSION: ${{github.event.release.tag_name}}
               run: |
-                    jq --arg url $URL '.url=$url' system.json > system.json
-                    jq --arg manifest $MANIFEST '.manifest=$manifest' system.json > system.json
-                    jq --arg download $DOWNLOAD '.download=$download' system.json > system.json
-                    jq --arg version $VERSION '.version=$version' system.json > system.json
+                    apt-get install moreutils
+                    jq --arg url $URL '.url=$url' system.json | sponge system.json
+                    jq --arg manifest $MANIFEST '.manifest=$manifest' system.json | sponge system.json
+                    jq --arg download $DOWNLOAD '.download=$download' system.json | sponge system.json
+                    jq --arg version $VERSION '.version=$version' system.json | sponge system.json
 
             - name: Read file contents
               id: read_file
@@ -37,8 +32,10 @@ jobs:
               with:
                 path: "system.json"
 
-            - name: Show manifest
-              run: echo "${{ steps.read_file.outputs.content }}"
+            - name: Read System manifest for later use
+              run: |
+                    cat system.json
+                    echo "MANIFEST_JSON=$(jq -c . < system.json)" >> $GITHUB_ENV
 
             - name: Build and package release artifacts
               run: |
@@ -63,8 +60,8 @@ jobs:
             - name: Deploy Release
               uses: fjogeleit/http-request-action@v1
               env:
-                  MINIMUM: ${{ fromJson(steps.read_file.outputs.content).compatibility.minimum }}
-                  VERIFIED: ${{ fromJson(steps.read_file.outputs.content).compatibility.verified }}
+                  MINIMUM: ${{ fromJson(env.MANIFEST_JSON).compatibility.minimum }}
+                  VERIFIED: ${{ fromJson(env.MANIFEST_JSON).compatibility.verified }}
               with:
                   url: 'https://api.foundryvtt.com/_api/packages/release_version'
                   method: 'POST'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,13 +11,13 @@ jobs:
             - uses: actions/checkout@v4
 
             - name: Read file contents
-              id: read_file
+              id: read_file_1
               uses: andstor/file-reader-action@v1
               with:
                 path: "system.json"
 
             - name: Show manifest
-              run: echo "${{ steps.read_file.outputs.content }}"
+              run: echo "${{ steps.read_file_1.outputs.content }}"
 
             - name: Modify System Manifest With Release-Specific Values
               env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -57,8 +57,8 @@ jobs:
             - name: Deploy Release
               uses: fjogeleit/http-request-action@v1
               env:
-                  MINIMUM: ${{ fromJson(env.MANIFEST_JSON).compatibility.minimum }}
-                  VERIFIED: ${{ fromJson(env.MANIFEST_JSON).compatibility.verified }}
+                  MINIMUM: ${{ fromJson(steps.read_file.outputs.content).compatibility.minimum }}
+                  VERIFIED: ${{ fromJson(steps.read_file.outputs.content).compatibility.verified }}
               with:
                   url: 'https://api.foundryvtt.com/_api/packages/release_version'
                   method: 'POST'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,6 +10,12 @@ jobs:
         steps:
             - uses: actions/checkout@v4
 
+            - name: Read file contents
+              id: read_file
+              uses: andstor/file-reader-action@v1
+              with:
+                path: "system.json"
+
             - name: Show manifest
               run: echo "${{ steps.read_file.outputs.content }}"
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -62,9 +62,10 @@ jobs:
               env:
                   MINIMUM: ${{ fromJson(env.MANIFEST_JSON).compatibility.minimum }}
                   VERIFIED: ${{ fromJson(env.MANIFEST_JSON).compatibility.verified }}
+                  MAXIMUM: 12
               with:
                   url: 'https://api.foundryvtt.com/_api/packages/release_version'
                   method: 'POST'
                   contentType: 'application/json'
                   customHeaders: '{"Authorization": "${{ secrets.FVTT_PACKAGE_RELEASE_TOKEN }}"}'
-                  data: '{"id": "shadowrun5e", "dry-run": true, "release":{"version":"v${{github.event.release.tag_name}}","manifest":"https://github.com/SR5-FoundryVTT/SR5-FoundryVTT/releases/latest/download/system.json","notes":"https://github.com/smilligan93/SR5-FoundryVTT/releases/tag/${{github.event.release.tag_name}}","compatibility":{"minimum":"$MINIMUM","verified":"$VERIFIED","maximum": 12}}}'
+                  data: '{"id": "shadowrun5e", "dry-run": true, "release":{"version":"v${{github.event.release.tag_name}}","manifest":"https://github.com/SR5-FoundryVTT/SR5-FoundryVTT/releases/latest/download/system.json","notes":"https://github.com/smilligan93/SR5-FoundryVTT/releases/tag/${{github.event.release.tag_name}}","compatibility":{"minimum":"${{ env.MINIMUM }}","verified":"${{ env.VERIFIED }}","maximum": "${{ env.MAXIMUM }}"}}}'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,6 +10,9 @@ jobs:
         steps:
             - uses: actions/checkout@v4
 
+            - name: Show manifest
+              run: echo "${{ steps.read_file.outputs.content }}"
+
             - name: Modify System Manifest With Release-Specific Values
               env:
                   URL: https://github.com/${{github.repository}}
@@ -22,11 +25,14 @@ jobs:
                     jq --arg download $DOWNLOAD '.download=$download' system.json > system.json
                     jq --arg version $VERSION '.version=$version' system.json > system.json
 
-            - name: Read System manifest for later use
-              run: |
-                    cat system.json
-                    echo "MANIFEST_JSON=$(jq -c . < system.json)" >> $GITHUB_ENV
-                    echo $GITHUB_ENV
+            - name: Read file contents
+              id: read_file
+              uses: andstor/file-reader-action@v1
+              with:
+                path: "system.json"
+
+            - name: Show manifest
+              run: echo "${{ steps.read_file.outputs.content }}"
 
             - name: Build and package release artifacts
               run: |


### PR DESCRIPTION
Reworked manifest update to use jq and sponge. Without sponge jq doesn´t support writing back into the source file without weird workarounds.

Reworked CD deployment to read values from manifest.

Removed as many external action dependencies as possible