### PR TITLE
[Bug] Prepared Spirit summons would create new spirit and summoned spirit wasn't draggable from chat message

### DIFF
--- a/src/module/tests/OpposedSummonSpiritTest.ts
+++ b/src/module/tests/OpposedSummonSpiritTest.ts
@@ -172,7 +172,7 @@ export class OpposedSummonSpiritTest extends OpposedTest<OpposedSummonSpiritTest
             // Reuse a prepared actor...
             const preparedActor = await this.getPreparedSpiritActor();
             if (!preparedActor) return console.error('Shadowrun 5e | Could not find prepared spirit actor');
-            preparedActor.update({ 'system.summonerUuid': summoner.uuid });
+            await preparedActor.update({ 'system.summonerUuid': summoner.uuid });
             
         } else {
             // Create a new spirit actor from scratch...
@@ -196,7 +196,7 @@ export class OpposedSummonSpiritTest extends OpposedTest<OpposedSummonSpiritTest
      * @returns 
      */
     async getPreparedSpiritActor(): Promise<SR5Actor|null> {
-        return await fromUuid(this.data.summonedSpiritUuid as string) as SR5Actor;
+        return await fromUuid(this.against.data.preparedSpiritUuid) as SR5Actor;
     }
 
     /**

--- a/src/templates/rolls/opposed-actor-creator-message.html
+++ b/src/templates/rolls/opposed-actor-creator-message.html
@@ -3,7 +3,7 @@
 <div class="sr5 chat-card roll-card">
     <div class="card-content">
         <div class="left-side">
-            <p><a class="content-link" draggable="true" data-uuid="{{test.actor.uuid}}" data-id="{{test.actor.id}}" data-type="Actor" data-tooltip="SR5.Tooltips.SummoningTest.DragOnCanvas"><i class="fas fa-user"></i>{{test.actor.name}}</a></p>
+            <p><a class="content-link" draggable="true" data-link="" data-uuid="{{test.actor.uuid}}" data-id="{{test.actor.id}}" data-type="Actor" data-tooltip="SR5.Tooltips.SummoningTest.DragOnCanvas"><i class="fas fa-user"></i>{{test.actor.name}}</a></p>
         </div>
     </div>
 </div>


### PR DESCRIPTION
- [Bug] When using prepared Spirit actor for summening a new spirit would be created
- [BUG] Can no longer drag and drop summoned spirits onto the canvas in Foundry v12
Fixes #1324