### PR TITLE
[Code] Support for a global data storage with GM socket handling using world settings.

### DIFF
--- a/src/module/constants.ts
+++ b/src/module/constants.ts
@@ -39,6 +39,7 @@ export const FLAGS = {
     DoNextRound: 'doNextRound',
     DoNewActionPhase: 'doNewActionPhase',
     addNetworkController: 'addNetworkController',
+    SetDataStorage: 'setDataStorage',
     TokenHealthBars: 'tokenHealthBars',
     Test: 'TestData',
     HideGMOnlyChatContent: 'HideGMOnlyChatContent',
@@ -53,7 +54,8 @@ export const FLAGS = {
     CreateTargetedEffects: 'CreateTargetedEffects',
     DefaultOpposedTestActorSelection: 'DefaultOpposedTestActorSelection',
     TeamworkTestFlow: 'TeamworkTestFlow',
-    UseDamageCondition: 'UseDamageCondition'
+    UseDamageCondition: 'UseDamageCondition',
+    GlobalDataStorage: 'GlobalDataStorage'
 };
 export const CORE_NAME = 'core';
 export const CORE_FLAGS = {

--- a/src/module/data/DataStorage.ts
+++ b/src/module/data/DataStorage.ts
@@ -1,0 +1,97 @@
+import { FLAGS, SYSTEM_NAME } from "../constants";
+import { SocketMessage } from "../sockets";
+
+/**
+ * Handle the global storage setting for the system.
+ * 
+ * This allows you to store data globally, without a FoundryVTT document, and retrieve it later.
+ * Since it's stored within a world setting, this will handle the GM socket updates for you.
+ * 
+ * NOTE: Foundry doesn´t do it's typical differential merge on updates, nor does it handle unset / delete.
+ * 
+ * Usage:
+ * > const mydata = game.shadowrun5e.storage.get('key1.key2');
+ * > mydata.subValue = 'new value';
+ * > await game.shadowrun5e.storage.set('key1.key2', mydata);
+ */
+export const DataStorage = {
+    /**
+     * Assure a usable data storage, even if data is lost.
+     */
+    validate: async function () {
+        console.debug('Shadowrun 5e | Validating global data storage.');
+        const storage = DataStorage.storage();
+        if (!storage || typeof storage !== 'object') {
+            ui.notifications?.error('Shadowrun 5e | Global data storage has been reset. Please check the console (F12) for more information.');
+            console.error('Shadowrun 5e | Global data storage could not be loaded. Resetting to empty object. This might cause some game information to be deleted.', storage);
+            await game.settings.set(SYSTEM_NAME, FLAGS.GlobalDataStorage, {});
+        }
+    },
+
+    /**
+     * Retrieve the top level storage object.
+     * 
+     * @returns object
+     */
+    storage: function(): any {
+        return game.settings.get(SYSTEM_NAME, FLAGS.GlobalDataStorage);
+    },
+
+    /**
+     * Overwrite the global data storage with a new object.
+     * 
+     * @param storage The complete global storage. This will fully overwrite the current storage.
+     */
+    save: async function(storage: any) {
+        await game.settings.set(SYSTEM_NAME, FLAGS.GlobalDataStorage, storage);
+    },
+
+    /**
+     * Retrieve a storage key from the global data storage in a FoundryVTT typical way.
+     * @param key A object property string 'key1.key2'
+     * @returns any or undefined if not found
+     */
+    get: function (key: string): any {
+        return foundry.utils.getProperty(this.storage(), key);
+    },
+
+    /**
+     * Store a value in the global data storage.
+     * 
+     * @param key A object property string 'key1.key2'
+     * @param value Any value to store. Take care to not overwrite complete objects, if unwanted.
+     */
+    set: async function (key: string, value: any) {
+        if (game.user?.isGM) await this._setAsGM(key, value);
+        else await this._setAsPlayer(key, value);
+    },
+
+    /**
+     * Store a value in the global data storage as GM, as players lack the permission for it.
+     */
+    _setAsGM: async function (key: string, value: any) {
+        const storage = this.storage();
+        console.debug('Shadowrun 5e | Setting a value in global data storage.', key, value, storage);
+        foundry.utils.setProperty(storage, key, value);
+        await DataStorage.save(storage);
+        console.debug('Shadowrun 5e | Value set in global data storage.', storage);
+    },
+
+    /**
+     * Store a value in the global data storage as a player, by requesting the GM to do it.
+     */
+    _setAsPlayer: async function (key: string, value: any) {
+        console.debug('Shadowrun 5e | Requesting GM to set a value in global data storage.', key, value);
+        await SocketMessage.emitForGM(FLAGS.SetDataStorage, {key, value});
+    },
+
+    /**
+     * Handle socket messages around setting data storage as GM only.
+     * @param message.data.key The set method key param
+     * @param message.data.value The set method value param
+     */
+    _handleSetDataStorageSocketMessage: async function (message: Shadowrun.SocketMessageData) {
+        if (!game.user?.isGM) return;
+        await DataStorage._setAsGM(message.data.key, message.data.value);
+    }
+}

--- a/src/module/hooks.ts
+++ b/src/module/hooks.ts
@@ -69,6 +69,7 @@ import { RenderSettings } from './systemLinks';
 import registerSR5Tours from './tours/tours';
 import { SuccessTestEffectsFlow } from './effect/flows/SuccessTestEffectsFlow';
 import { JournalEnrichers } from './journal/enricher';
+import { DataStorage } from './data/DataStorage';
 
 
 
@@ -241,7 +242,12 @@ ___________________
              * This came out of an unclear user issue regarding multi-char UTF symbol inputs, to allow
              * 'interactive' changing of the delay on the user side until a sweet spot could be found.
              */
-            inputDelay: 300
+            inputDelay: 300,
+
+            /**
+             * The global data storage for the system.
+             */
+            storage: DataStorage
         };
 
         // Register document classes
@@ -332,6 +338,7 @@ ___________________
         // Register Tours
         registerSR5Tours();
 
+        DataStorage.validate();
     }
 
     static async ready() {
@@ -475,7 +482,8 @@ ___________________
             [FLAGS.DoInitPass]: [SR5Combat._handleDoInitPassSocketMessage],
             [FLAGS.DoNewActionPhase]: [SR5Combat._handleDoNewActionPhaseSocketMessage],
             [FLAGS.CreateTargetedEffects]: [SuccessTestEffectsFlow._handleCreateTargetedEffectsSocketMessage],
-            [FLAGS.TeamworkTestFlow]: [TeamworkTest._handleUpdateSocketMessage]
+            [FLAGS.TeamworkTestFlow]: [TeamworkTest._handleUpdateSocketMessage],
+            [FLAGS.SetDataStorage]: [DataStorage._handleSetDataStorageSocketMessage],
         }
 
         game.socket.on(SYSTEM_SOCKET, async (message: Shadowrun.SocketMessageData) => {

--- a/src/module/settings.ts
+++ b/src/module/settings.ts
@@ -2,9 +2,22 @@
 
 import { VersionMigration } from './migrator/VersionMigration';
 import { FLAGS, SYSTEM_NAME } from './constants';
-import { boolean } from 'fast-check';
 
 export const registerSystemSettings = () => {
+    /**
+     * No actual setting.
+     * 
+     * Instead this is used to store global data outside of FoundryVTT document storage.
+     * See DataStorage.ts for more information.
+     */
+    game.settings.register(SYSTEM_NAME, FLAGS.GlobalDataStorage, {
+        name: 'SETTINGS.GlobalDataStorageName',
+        hint: 'SETTINGS.GlobalDataStorageDescription',
+        scope: 'world',
+        config: false,
+        type: Object,
+        default: {}
+    });
 
     /**
      * Register diagonal movement rule setting

--- a/src/module/sockets.ts
+++ b/src/module/sockets.ts
@@ -28,11 +28,28 @@ export class SocketMessage {
         if (!game.socket || !game.user || !game.users) return;
         if (game.user.isGM) return console.error('Active user is GM! Aborting socket message...');
 
+        SocketMessage._assertActiveGMUser();
+
         const gmUser = game.users.find(user => user.isGM);
         if (!gmUser) return console.error('No active GM user! One GM must be active for this action to work.');
 
         const message = SocketMessage._createMessage(type, data, gmUser.id);
         console.trace('Shadowrun 5e | Emitting Shadowrun5e system socket message', message);
         await game.socket.emit(SYSTEM_SOCKET, message);
+    }
+
+    /**
+     * Assert at least one active GM user to avoid confusing bugs when none is present and gm socket message
+     * aren´t handeled.
+     * 
+     * If that's the case, also inform users to avoid confusion.
+     */
+    static _assertActiveGMUser() {
+        if (!game.users) return;
+        for (const user of game.users) {
+            if (user.active && user.isGM) return;
+        }
+        ui.notifications?.error('There is no active GM user to perform this action. Please ask your GM to logon.');
+        throw new Error('Shadowrun 5e | No active GM user found.');
     }
 }


### PR DESCRIPTION
Introduce a hidden world scope setting used as a general data storage outside of individual FoundryVTT documents.

The DataStorage.ts is introduced to improve usability and handle these edge cases:
- Foundry doesn´t diff on update but overwrite the setting as a whole (#set method)
- Foundry disallows players to set world scope settings. For players send a GM only socket message to handle storage saves by players.

I also extended the SocketMessage.emitForGM method to actually check if any GM are online to avoid 'why is nothing happening' states when only players are online.
