### PR TITLE
[BUG] Attributes cannot be reduced to 0

### DIFF
--- a/src/module/actor/prep/SpiritPrep.ts
+++ b/src/module/actor/prep/SpiritPrep.ts
@@ -15,6 +15,7 @@ import { CharacterPrep } from './CharacterPrep';
 import { GruntPrep } from './functions/GruntPrep';
 import { DataDefaults } from '../../data/DataDefaults';
 import { SR5 } from '../../config';
+import { SR } from '../../constants';
 
 
 export class SpiritPrep {
@@ -30,7 +31,8 @@ export class SpiritPrep {
     static prepareDerivedData(system: SpiritData, items: SR5ItemDataWrapper[]) {
         SpiritPrep.prepareSpiritBaseData(system);
 
-        AttributesPrep.prepareAttributes(system);
+        // Use spirit attribute range to avoid issues with attribute calculation causing unusable attributes.
+        AttributesPrep.prepareAttributes(system, SR.attributes.rangesSpirit);
         SpiritPrep.prepareAttributesWithForce(system);
         SkillsPrep.prepareSkills(system);
 

--- a/src/module/actor/prep/functions/AttributesPrep.ts
+++ b/src/module/actor/prep/functions/AttributesPrep.ts
@@ -11,7 +11,7 @@ export class AttributesPrep {
     /**
      * Prepare actor data for attributes
      */
-    static prepareAttributes(system: ActorTypesData) {
+    static prepareAttributes(system: ActorTypesData, ranges?: Record<string, {min: number, max?: number}>) {
         const {attributes} = system;
 
         // always have special attributes set to hidden
@@ -26,7 +26,7 @@ export class AttributesPrep {
             // needed to be able to migrate things correctly
             if (name === 'edge' && attribute['uses'] === undefined) return;
 
-            AttributesPrep.prepareAttribute(name, attribute)
+            AttributesPrep.prepareAttribute(name, attribute, ranges)
         }
     }
 
@@ -35,13 +35,13 @@ export class AttributesPrep {
      * @param name The key field (and name) of the attribute given
      * @param attribute The AttributeField to prepare
      */
-    static prepareAttribute(name: string, attribute: AttributeField) {
+    static prepareAttribute(name: string, attribute: AttributeField, ranges?: Record<string, {min: number, max?: number}>) {
         // Check for valid attributes. Active Effects can cause unexpected properties to appear.
         if (!SR5.attributes.hasOwnProperty(name) || !attribute) return;
 
         // Each attribute can have a unique value range.
         // TODO:  Implement metatype attribute value ranges for character actors.
-        AttributesPrep.calculateAttribute(name, attribute);
+        AttributesPrep.calculateAttribute(name, attribute, ranges);
 
         // add i18n labels.
         attribute.label = SR5.attributes[name];
@@ -53,13 +53,13 @@ export class AttributesPrep {
      * @param name The attributes name / id
      * @param attribute The attribute will be modified in place
      */
-    static calculateAttribute(name: string, attribute: AttributeField) {
+    static calculateAttribute(name: string, attribute: AttributeField, ranges?: Record<string, {min: number, max?: number}>) {
         // Check for valid attributes. Active Effects can cause unexpected properties to appear.
         if (!SR5.attributes.hasOwnProperty(name) || !attribute) return;
 
         // Each attribute can have a unique value range.
         // TODO:  Implement metatype attribute value ranges for character actors.
-        const range = SR.attributes.ranges[name];
+        const range = ranges ? ranges[name] : SR.attributes.ranges[name];
         Helpers.calcTotal(attribute, range);
     }
 

--- a/src/module/constants.ts
+++ b/src/module/constants.ts
@@ -116,10 +116,35 @@ export const SR = {
     attributes: {
         // Use for min/max value ranges (general). This will need expanding for different metatypes, should that ever
         // come to  be.
+        // These are the most extreme outer, possible modified values for each attribute.
         ranges: {
             magic: {min: 0},
             edge: {min: 0},
             resonance: {min: 0},
+            essence: {min: 0},
+            body: {min: 0},
+            agility: {min: 0},
+            reaction: {min: 0},
+            strength: {min: 0},
+            willpower: {min: 0},
+            logic: {min: 0},
+            intuition: {min: 0},
+            charisma: {min: 0},
+            attack: {min: 0},
+            sleaze: {min: 0},
+            data_processing: {min: 0},
+            firewall: {min: 0},
+            host_rating: {min: 0, max: 12},
+            pilot: {min: 0},
+            force: {min: 0}
+        },
+        /**
+         * Spirits on creation can have calculated attributes that would lower them to 0 or lower, but still have to have a min value of
+         * 1 for each.
+         */
+        rangesSpirit: {
+            magic: {min: 0},
+            edge: {min: 0},
             essence: {min: 0},
             body: {min: 1},
             agility: {min: 1},
@@ -129,12 +154,7 @@ export const SR = {
             logic: {min: 1},
             intuition: {min: 1},
             charisma: {min: 1},
-            attack: {min: 0},
-            sleaze: {min: 0},
-            data_processing: {min: 0},
-            firewall: {min: 0},
-            host_rating: {min: 0, max: 12},
-            pilot: {min: 1},
+            pilot: {min: 0},
             force: {min: 1}
         },
         // Use for initial default values that aren't simply range.<>.min values.


### PR DESCRIPTION
Fixes #1090

The system doesn't differentiate between setting intial value ratings and calculating their value later on.

This fix will make 90% of all cases where an effect should reduce an attribute to zero possible, while preserving the spirit attribute calculation setting their values to 1, even if not enough force has been used to do so.

A better approach would separate between actor creation and data preparation, possibly using the _create and _update method on SR5Actor to set initial base ratings, while still calculating actual values during data preparation.