### PR TITLE
[BUG] Active Effects can't Upgrade from Zero

### DIFF
--- a/src/module/actor/prep/CharacterPrep.ts
+++ b/src/module/actor/prep/CharacterPrep.ts
@@ -18,6 +18,8 @@ import { DataDefaults } from '../../data/DataDefaults';
 export class CharacterPrep {
     static prepareBaseData(system: Shadowrun.CharacterData) {
         CharacterPrep.addSpecialAttributes(system);
+        SkillsPrep.prepareSkillData(system);
+
         ModifiersPrep.prepareModifiers(system);
         ModifiersPrep.clearAttributeMods(system);
         ModifiersPrep.clearArmorMods(system);

--- a/src/module/actor/prep/CritterPrep.ts
+++ b/src/module/actor/prep/CritterPrep.ts
@@ -19,6 +19,7 @@ export class CritterPrep {
         ModifiersPrep.clearAttributeMods(system);
         ModifiersPrep.clearArmorMods(system);
         ModifiersPrep.clearLimitMods(system);
+        SkillsPrep.prepareSkillData(system);
     }
 
     static prepareDerivedData(system: CritterData, items: SR5ItemDataWrapper[]) {

--- a/src/module/actor/prep/ICPrep.ts
+++ b/src/module/actor/prep/ICPrep.ts
@@ -49,7 +49,7 @@ export class ICPrep {
      */
     static addMissingTracks(system: ICData) {
         // Newly created actors SHOULD have this by template.
-        // Legacy actors MIGHT not have it, therefore make sure it's their.
+        // Legacy actors MIGHT not have it, therefore make sure it's there.
         const track = system.track || {};
         if (!track.matrix) track.matrix = DataDefaults.trackData();
         system.track = track;

--- a/src/module/actor/prep/ICPrep.ts
+++ b/src/module/actor/prep/ICPrep.ts
@@ -16,6 +16,7 @@ export class ICPrep {
     static prepareBaseData(system: ICData) {
         ModifiersPrep.clearAttributeMods(system);
         ModifiersPrep.clearLimitMods(system);
+        SkillsPrep.prepareSkillData(system);
 
         ICPrep.addMissingTracks(system);
         ICPrep.prepareModifiers(system);

--- a/src/module/actor/prep/SpiritPrep.ts
+++ b/src/module/actor/prep/SpiritPrep.ts
@@ -20,6 +20,7 @@ import { SR5 } from '../../config';
 export class SpiritPrep {
     static prepareBaseData(system: SpiritData) {
         SpiritPrep.prepareSpiritSpecial(system);
+        SkillsPrep.prepareSkillData(system);
 
         ModifiersPrep.prepareModifiers(system);
         ModifiersPrep.clearAttributeMods(system);

--- a/src/module/actor/prep/SpritePrep.ts
+++ b/src/module/actor/prep/SpritePrep.ts
@@ -17,6 +17,7 @@ import {SR5ItemDataWrapper} from "../../data/SR5ItemDataWrapper";
 export class SpritePrep {
     static prepareBaseData(data: SpriteData) {
         SpritePrep.prepareSpriteSpecial(data);
+        SkillsPrep.prepareSkillData(data);
 
         ModifiersPrep.prepareModifiers(data);
         ModifiersPrep.clearAttributeMods(data);

--- a/src/module/actor/prep/VehiclePrep.ts
+++ b/src/module/actor/prep/VehiclePrep.ts
@@ -15,6 +15,8 @@ import { SR } from '../../constants';
 
 export class VehiclePrep {
     static prepareBaseData(system: Shadowrun.VehicleData) {
+        SkillsPrep.prepareSkillData(system);
+
         ModifiersPrep.prepareModifiers(system);
         ModifiersPrep.clearAttributeMods(system);
         ModifiersPrep.clearArmorMods(system);

--- a/src/module/actor/prep/functions/SkillsPrep.ts
+++ b/src/module/actor/prep/functions/SkillsPrep.ts
@@ -5,6 +5,22 @@ import ActorTypesData = Shadowrun.ShadowrunActorDataData;
 
 export class SkillsPrep {
     /**
+     * Prepare missing skill data as early in during data preparation as possible.
+     * 
+     * template.json is incomplete, so we need to fill in the missing fields.
+     * This is mostly a legacy design and should be fixed in the future when DataModel's are used.
+     * @param system 
+     */
+    static prepareSkillData(system: ActorTypesData) {
+        const { language, active, knowledge } = system.skills;
+        Object.values(language.value).forEach((skill) => { _mergeWithMissingSkillFields(skill)} );
+        Object.values(active).forEach((skill) => { _mergeWithMissingSkillFields(skill)} );
+        Object.values(knowledge).forEach((group) => {
+            Object.values(group.value).forEach((skill) => { _mergeWithMissingSkillFields(skill)} );
+        });
+    }
+
+    /**
      * Prepare actor data for skills
      */
     static prepareSkills(system: ActorTypesData) {
@@ -34,8 +50,6 @@ export class SkillsPrep {
             }
             skill.value = Helpers.calcTotal(skill);
 
-            // Older Chummer imports miss some fields.
-            _mergeWithMissingSkillFields(skill);
         };
 
         // setup active skills
@@ -92,7 +106,7 @@ export const _mergeWithMissingSkillFields = (givenSkill) => {
     // Only the absolute most necessary fields, not datatype complete to SkillField
     const template = {
         name: "",
-        base: "",
+        base: 0,
         value: 0,
         attribute: "",
         mod: [],


### PR DESCRIPTION
Fixes #1058

template.json has incomplete data for each skill, missing base. Since base is used during effects apply the field is missing and therefore undefined. This causes it to be ignored during the upgrade apply as it only supports boolean and number.

Missing data was already injected into all skills during preparation of derived data. As effects are applied between base and derived data prep, the data injection was moved to base prep.