### PR TITLE
[Chummer] Critter Powers will be imported with folders for categories

### DIFF
--- a/src/module/apps/itemImport/importer/CritterPowerImporter.ts
+++ b/src/module/apps/itemImport/importer/CritterPowerImporter.ts
@@ -28,7 +28,12 @@ export class CritterPowerImporter extends DataImporter<Shadowrun.CritterPowerIte
 
     async Parse(chummerPowers: object, setIcons: boolean): Promise<Item> {
         const parser = new CritterPowerParserBase();
-        const folder = await ImportHelper.GetFolderAtPath(`${Constants.ROOT_IMPORT_FOLDER_NAME}/${game.i18n.localize('TYPES.Item.critter_power')}`, true);
+
+        chummerPowers['categories']['category'] = chummerPowers['categories']['category'].filter(
+            (power) => !["Emergent", "Toxic Critter Powers"].includes(power._TEXT)
+        ).concat({ _TEXT: "Other" });
+        const folders = await ImportHelper.MakeCategoryFolders(chummerPowers, game.i18n.localize('TYPES.Item.critter_power'), this.categoryTranslations);
+
         const items: Shadowrun.CritterPowerItemData[] = [];
         const chummerCritterPowers = this.filterObjects(chummerPowers['powers']['power']);
         this.iconList = await this.getIconFiles();
@@ -44,7 +49,7 @@ export class CritterPowerImporter extends DataImporter<Shadowrun.CritterPowerIte
             // Create the item
             const item = parser.Parse(chummerCritterPower, this.GetDefaultData({type: parserType}), this.itemTranslations);
             // @ts-expect-error TODO: foundry-vtt-type v10
-            item.folder = folder.id;
+            item.folder = folders[item.system.category]?.id || folders["other"].id;
 
             // Import Flags
             item.system.importFlags = this.genImportFlags(item.name, item.type, item.system.powerType);

--- a/src/module/apps/itemImport/importer/SpritePowerImporter.ts
+++ b/src/module/apps/itemImport/importer/SpritePowerImporter.ts
@@ -18,6 +18,7 @@ export class SpritePowerImporter extends DataImporter<Shadowrun.SpritePowerItemD
         'Mundane',
         'Paranormal',
         'Paranormal/Infected',
+        'Mundane/Infected',
         'Toxic Critter Powers',
         'Weakness',
         'Chimeric Modification',

--- a/src/module/apps/itemImport/parser/critter-power/CritterPowerParserBase.ts
+++ b/src/module/apps/itemImport/parser/critter-power/CritterPowerParserBase.ts
@@ -8,7 +8,9 @@ export class CritterPowerParserBase extends ItemParserBase<CritterPowerItemData>
         item.name = ImportHelper.StringValue(jsonData, 'name');
 
         item.system.description.source = `${ImportHelper.StringValue(jsonData, 'source')} ${ImportHelper.StringValue(jsonData, 'page')}`;
-        item.system.category = ImportHelper.StringValue(jsonData, 'category').toLowerCase() as CritterPowerCategory;
+
+        const category = ImportHelper.StringValue(jsonData, 'category').toLowerCase();
+        item.system.category = (category.includes("infected") ? "infected" : category) as CritterPowerCategory;
 
         let duration = ImportHelper.StringValue(jsonData, 'duration');
         if (duration === 'Always') {


### PR DESCRIPTION
Divide the Critter Power in categories, since it has over 300 items.
Also fix bug that adds `Pounce (Infected)` twice.