### PR TITLE
[FEATURE] Add support for optionnal powers

### DIFF
--- a/public/locale/en/config.json
+++ b/public/locale/en/config.json
@@ -281,6 +281,12 @@
         "Types": {
             "Mana": "Mana",
             "Physical": "Physical"
+        },
+        "IsOptional": "Optionality",
+        "Optional": {
+            "Standard": "By default",
+            "EnabledOption": "Optional, enabled",
+            "DisabledOption": "Optional, disabled"
         }
     },
     "SR5.Cyberware": "Cyberware",
@@ -591,6 +597,8 @@
         "ActorSheet": {
             "CreateInventory": "Create inventory place",
             "CritterPowers": "Critter Powers",
+            "EnabledOptionCritterPowers": "Optional Critter Powers - Enabled",
+            "DisabledOptionCritterPowers": "Optional Critter Powers - Disabled",
             "DeviceRating": "Device Rating",
             "ICConfiguration": "IC Configuration",
             "Matrix": "Matrix",
@@ -605,6 +613,8 @@
             "SpiritConfiguration": "Spirit Configuration",
             "SpriteConfiguration": "Sprite Configuration",
             "SpritePowers": "Sprite Powers",
+            "EnabledOptionSpritePowers": "Optional Sprite Powers - Enabled",
+            "DisabledOptionSpritePowers": "Optional Sprite Powers - Disabled",
             "TestKBoardModifiers": "{skip}: skip dialog. {descr}: show only description.",
             "VehicleConfiguration": "Vehicle Configuration"
         },
@@ -1127,7 +1137,13 @@
         }
     },
     "SR5.SpritePower": {
-        "Type": "Type"
+        "Type": "Type",
+        "IsOptional": "Optionality",
+        "Optional": {
+            "Standard": "By default",
+            "EnabledOption": "Optional, enabled",
+            "DisabledOption": "Optional, disabled"
+        }
     },
     "SR5.Stock": "Stock",
     "SR5.StreetCred": "Street Cred",

--- a/public/locale/fr/config.json
+++ b/public/locale/fr/config.json
@@ -175,6 +175,12 @@
         "Types": {
             "Mana": "Mana",
             "Physical": "Physique"
+        },
+        "IsOptional": "Optionel",
+        "Optional": {
+            "Standard": "Par défaut",
+            "EnabledOption": "Optionel, enabled",
+            "DisabledOption": "Optionel, disabled"
         }
     },
     "SR5.Cyberware": "Cyberware",
@@ -355,6 +361,8 @@
     "SR5.Labels": {
         "ActorSheet": {
             "CritterPowers": "Pouvoirs",
+            "EnabledOptionCritterPowers": "Pouvoirs Optionels - Activés",
+            "DisabledOptionCritterPowers": "Pouvoirs Optionels - Désactivés",
             "DeviceRating": "Indice d'appareil",
             "Rituals": "Rituels",
             "RollDroneInfiltration": "Infiltration du drone",
@@ -364,7 +372,9 @@
             "Spells": "Sorts",
             "SpiritConfiguration": "Configuration d'esprit",
             "SpriteConfiguration": "Configuration de sprite",
-            "SpritePowers": "Pouvoirs de sprites",
+            "SpritePowers": "Pouvoirs",
+            "EnabledOptionSpritePowers": "Pouvoirs Optionels - Activés",
+            "DisabledOptionSpritePowers": "Pouvoirs Optionels - Désactivés",
             "VehicleConfiguration": "Configuration véhicule"
         }
     },
@@ -744,7 +754,13 @@
         }
     },
     "SR5.SpritePower": {
-        "Type": "Type"
+        "Type": "Type",
+        "IsOptional": "Optionel",
+        "Optional": {
+            "Standard": "Par défaut",
+            "EnabledOption": "Optionel, enabled",
+            "DisabledOption": "Optionel, disabled"
+        }
     },
     "SR5.Stock": "Stock",
     "SR5.StreetCred": "Réputation",

--- a/src/module/actor/sheets/SR5BaseActorSheet.ts
+++ b/src/module/actor/sheets/SR5BaseActorSheet.ts
@@ -1033,6 +1033,9 @@ export class SR5BaseActorSheet extends ActorSheet {
         // @ts-expect-error
         sheetItem.properties = chatData.properties;
 
+        if(item.isCritterPower || item.isSpritePower)
+            console.log(item.system);
+
         return sheetItem as unknown as SheetItemData;
     }
 

--- a/src/module/actor/sheets/SR5BaseActorSheet.ts
+++ b/src/module/actor/sheets/SR5BaseActorSheet.ts
@@ -283,6 +283,7 @@ export class SR5BaseActorSheet extends ActorSheet {
         html.find('.item-qty').on('change', this._onListItemChangeQuantity.bind(this));
         html.find('.item-rtg').on('change', this._onListItemChangeRating.bind(this));
         html.find('.item-equip-toggle').on('click', this._onListItemToggleEquipped.bind(this));
+        html.find('.item-enable-toggle').on('click', this._onListItemToggleEnabled.bind(this));
 
         // Item list description display handling...
         html.find('.hidden').hide();
@@ -1545,6 +1546,25 @@ export class SR5BaseActorSheet extends ActorSheet {
 
         this.actor.render(false);
     }
+
+    /**
+     * Change the enabled status of an item shown within a sheet item list.
+     */
+        async _onListItemToggleEnabled(event) {
+            event.preventDefault();
+            const iid = Helpers.listItemId(event);
+            const item = this.actor.items.get(iid);
+            if (!item) return;
+            if (!item.isCritterPower && !item.isSpritePower) return;
+    
+            // Handle the enabled state.
+            await this.actor.updateEmbeddedDocuments('Item', [{
+                '_id': iid,
+                'system.enabled': !item.isEnabled(),
+            }]);
+    
+            this.actor.render(false);
+        }
 
     /**
      * Show / hide the items description within a sheet item l ist.

--- a/src/module/config.ts
+++ b/src/module/config.ts
@@ -986,6 +986,11 @@ export const SR5 = {
             permanent: 'SR5.CritterPower.Durations.Permanent',
             special: 'SR5.CritterPower.Durations.Special',
         },
+        optional: {
+            standard: 'SR5.CritterPower.Optional.Standard',
+            enabled_option: 'SR5.CritterPower.Optional.EnabledOption',
+            disabled_option: 'SR5.CritterPower.Optional.DisabledOption',
+        },
     },
 
     spriteTypes: {
@@ -996,6 +1001,21 @@ export const SR5 = {
         machine: 'SR5.Sprite.Types.Machine',
         companion: 'SR5.Sprite.Types.Companion',
         generalist:'SR5.Sprite.Types.Generalist',
+    },
+
+    spritePower: {
+        durations: {
+            always: 'SR5.SpritePower.Durations.Always',
+            instant: 'SR5.SpritePower.Durations.Instant',
+            sustained: 'SR5.SpritePower.Durations.Sustained',
+            permanent: 'SR5.SpritePower.Durations.Permanent',
+            special: 'SR5.SpritePower.Durations.Special',
+        },
+        optional: {
+            standard: 'SR5.SpritePower.Optional.Standard',
+            enabled_option: 'SR5.SpritePower.Optional.EnabledOption',
+            disabled_option: 'SR5.SpritePower.Optional.DisabledOption',
+        },
     },
 
     vehicle: {

--- a/src/module/data/SR5ItemDataWrapper.ts
+++ b/src/module/data/SR5ItemDataWrapper.ts
@@ -15,6 +15,8 @@ import AmmunitionData = Shadowrun.AmmunitionData;
 import WeaponData = Shadowrun.WeaponData;
 import DeviceData = Shadowrun.DeviceData;
 import AmmoData = Shadowrun.AmmoData;
+import SpritePowerData = Shadowrun.SpritePowerData;
+import CritterPowerData = Shadowrun.CritterPowerData;
 
 export class SR5ItemDataWrapper extends DataWrapper<ShadowrunItemData> {
     getType() {
@@ -206,7 +208,13 @@ export class SR5ItemDataWrapper extends DataWrapper<ShadowrunItemData> {
     }
 
     isEnabled(): boolean {
-        return this.getData().enabled || false;
+        if(!this.isCritterPower && !this.isSpritePower) return false;
+        return this.getData().enabled !== undefined ? this.getData().enabled === true : true;
+    }
+
+    canBeDisabled(): boolean {
+        if(!this.isCritterPower && !this.isSpritePower) return false;
+        return (this.getData().optional || 'standard') !== 'standard'
     }
 
     isWireless(): boolean {

--- a/src/module/data/SR5ItemDataWrapper.ts
+++ b/src/module/data/SR5ItemDataWrapper.ts
@@ -205,6 +205,10 @@ export class SR5ItemDataWrapper extends DataWrapper<ShadowrunItemData> {
         return this.getData().technology?.equipped || false;
     }
 
+    isEnabled(): boolean {
+        return this.getData().enabled || false;
+    }
+
     isWireless(): boolean {
         return this.getData().technology?.wireless || false;
     }

--- a/src/module/effect/SR5ActiveEffect.ts
+++ b/src/module/effect/SR5ActiveEffect.ts
@@ -241,6 +241,8 @@ export class SR5ActiveEffect extends ActiveEffect {
 
         if (this.onlyForEquipped && !this.parent.isEquipped()) return true;
         if (this.onlyForWireless && !this.parent.isWireless()) return true;
+        if (this.parent.isCritterPower && !this.parent.isEnabled()) return true;
+        if (this.parent.isSpritePower && !this.parent.isEnabled()) return true;
 
         return false; 
     }

--- a/src/module/handlebars/ItemLineHelpers.ts
+++ b/src/module/handlebars/ItemLineHelpers.ts
@@ -754,7 +754,8 @@ export const registerItemLineHelpers = () => {
                 break;
             case 'critter_power':
             case 'sprite_power':
-                icons.unshift(enableIcon);
+                if(wrapper.canBeDisabled()) icons.unshift(enableIcon);
+                break;
         }
 
         return icons;

--- a/src/module/handlebars/ItemLineHelpers.ts
+++ b/src/module/handlebars/ItemLineHelpers.ts
@@ -731,6 +731,10 @@ export const registerItemLineHelpers = () => {
             icon: `${wrapper.isEquipped() ? 'fas fa-check-circle' : 'far fa-circle'} item-equip-toggle`,
             title: game.i18n.localize('SR5.ToggleEquip'),
         };
+        const enableIcon = {
+            icon: `${wrapper.isEnabled() ? 'fas fa-check-circle' : 'far fa-circle'} item-enable-toggle`,
+            title: game.i18n.localize('SR5.ToggleEquip'),
+        }
         const pdfIcon = {
             icon: 'fas fa-file open-source',
             title: game.i18n.localize('SR5.OpenSource'),
@@ -747,6 +751,10 @@ export const registerItemLineHelpers = () => {
             case 'bioware':
             case 'weapon':
                 icons.unshift(equipIcon);
+                break;
+            case 'critter_power':
+            case 'sprite_power':
+                icons.unshift(enableIcon);
         }
 
         return icons;

--- a/src/module/item/SR5Item.ts
+++ b/src/module/item/SR5Item.ts
@@ -1208,6 +1208,10 @@ export class SR5Item extends Item {
         return this.wrapper.isEquipped();
     }
 
+    isEnabled(): boolean {
+        return this.wrapper.isEnabled();
+    }
+
     isWireless(): boolean {
         return this.wrapper.isWireless();
     }

--- a/src/module/item/SR5ItemSheet.ts
+++ b/src/module/item/SR5ItemSheet.ts
@@ -369,6 +369,8 @@ export class SR5ItemSheet extends ItemSheet {
 
         html.find('.list-item').each(this._addDragSupportToListItemTemplatePartial.bind(this));
 
+        html.find('.power-optional-input').on('change', this._onPowerOptionalInputChanged.bind(this));
+
         this._activateTagifyListeners(html);
     }
 
@@ -974,5 +976,35 @@ export class SR5ItemSheet extends ItemSheet {
         if (!this.document.isEquipped()) return;
 
         await this.document.parent.equipOnlyOneItemOfType(this.document);
+    }
+
+    /**
+     * Change the enabled status of an item shown within a sheet item list.
+     */
+    async _onPowerOptionalInputChanged(event) {
+        event.preventDefault();
+        if (!this.item.isCritterPower && !this.item.isSpritePower) return;
+
+        let selectedRangeCategory;
+
+        if (this.item.isCritterPower) {
+            selectedRangeCategory = event.currentTarget.value as keyof typeof SR5.critterPower.optional;
+        } else {
+            selectedRangeCategory = event.currentTarget.value as keyof typeof SR5.spritePower.optional;
+        }
+
+        this.item.system.optional = selectedRangeCategory;
+
+        switch (this.item.system.optional) {
+            case 'standard':
+            case 'enabled_option':
+                this.item.system.enabled = true;
+                break;
+            case 'disabled_option':
+                this.item.system.enabled = false;
+                break;
+        }
+
+        this.item.render(false);
     }
 }

--- a/src/module/types/item/CritterPower.ts
+++ b/src/module/types/item/CritterPower.ts
@@ -5,7 +5,6 @@ declare namespace Shadowrun {
         DescriptionPartData,
         ImportFlags,
         ArmorPartData {
-
     }
 
     export interface CritterPowerPartData {
@@ -15,6 +14,8 @@ declare namespace Shadowrun {
         duration: keyof typeof SR5CONFIG.critterPower.durations;
         karma: number;
         rating: number;
+        optional: keyof typeof SR5CONFIG.critterPower.optional;
+        enabled: boolean
     }
 
     export type CritterPowerCategory = 'mundane' | 'paranormal' | 'weakness' | 'emergent' | 'drake' | 'shapeshifter' | 'free_spirit' | 'paranormal_infected' | 'echoes' | '';

--- a/src/module/types/item/SpritePower.ts
+++ b/src/module/types/item/SpritePower.ts
@@ -1,9 +1,15 @@
 /// <reference path="../Shadowrun.ts" />
 declare namespace Shadowrun {
     export interface SpritePowerData extends
+        SpritePowerPartData,
         ActionPartData,
         ImportFlags,
         DescriptionPartData {
+    }
 
+    export interface SpritePowerPartData {
+        duration: keyof typeof SR5CONFIG.spritePower.durations;
+        optional: keyof typeof SR5CONFIG.spritePower.optional;
+        enabled: boolean
     }
 }

--- a/src/templates/actor/parts/matrix/SpritePowerList.html
+++ b/src/templates/actor/parts/matrix/SpritePowerList.html
@@ -5,7 +5,7 @@
             icons=(ItemHeaderIcons 'sprite_power')
             rightSide=(ItemHeaderRightSide 'sprite_power')
     }}
-    {{#each itemType.sprite_power as |item i|}} {{#unless system.optional}}
+    {{#each itemType.sprite_power as |item i|}} {{#if (or (not system.optional) (eq system.optional "standard"))}}
         {{> 'systems/shadowrun5e/dist/templates/common/List/ListItem.html'
             img=item.img
             name=item.name
@@ -16,26 +16,7 @@
             hasRoll="true"
             description=item.description.value
         }}
-    {{/unless}} {{/each}}
-
-    {{> 'systems/shadowrun5e/dist/templates/common/List/ListHeader.html'
-            name=(localize 'SR5.Labels.ActorSheet.StandardSpritePowers')
-            itemId='standard_sprite_power'
-            icons=(ItemHeaderIcons 'sprite_power')
-            rightSide=(ItemHeaderRightSide 'sprite_power')
-    }}
-    {{#each itemType.sprite_power as |item i|}} {{#ife system.optional "standard"}}
-        {{> 'systems/shadowrun5e/dist/templates/common/List/ListItem.html'
-            img=item.img
-            name=item.name
-            itemId=item._id
-            icons=(ItemIcons item)
-            rightSide=(ItemRightSide item)
-            hasDesc="true"
-            hasRoll="true"
-            description=item.description.value
-        }}
-    {{/ife}} {{/each}}
+    {{/if}} {{/each}}
 
     {{> 'systems/shadowrun5e/dist/templates/common/List/ListHeader.html'
             name=(localize 'SR5.Labels.ActorSheet.EnabledOptionSpritePowers')

--- a/src/templates/actor/parts/matrix/SpritePowerList.html
+++ b/src/templates/actor/parts/matrix/SpritePowerList.html
@@ -5,16 +5,73 @@
             icons=(ItemHeaderIcons 'sprite_power')
             rightSide=(ItemHeaderRightSide 'sprite_power')
     }}
-    {{#each itemType.sprite_power as |item iid|}}
+    {{#each itemType.sprite_power as |item i|}} {{#unless system.optional}}
         {{> 'systems/shadowrun5e/dist/templates/common/List/ListItem.html'
-                img=item.img
-                name=item.name
-                itemId=item._id
-                icons=(ItemIcons item)
-                rightSide=(ItemRightSide item)
-                hasDesc="true"
-                hasRoll="true"
-                description=item.description.value
+            img=item.img
+            name=item.name
+            itemId=item._id
+            icons=(ItemIcons item)
+            rightSide=(ItemRightSide item)
+            hasDesc="true"
+            hasRoll="true"
+            description=item.description.value
         }}
-    {{/each}}
+    {{/unless}} {{/each}}
+
+    {{> 'systems/shadowrun5e/dist/templates/common/List/ListHeader.html'
+            name=(localize 'SR5.Labels.ActorSheet.StandardSpritePowers')
+            itemId='standard_sprite_power'
+            icons=(ItemHeaderIcons 'sprite_power')
+            rightSide=(ItemHeaderRightSide 'sprite_power')
+    }}
+    {{#each itemType.sprite_power as |item i|}} {{#ife system.optional "standard"}}
+        {{> 'systems/shadowrun5e/dist/templates/common/List/ListItem.html'
+            img=item.img
+            name=item.name
+            itemId=item._id
+            icons=(ItemIcons item)
+            rightSide=(ItemRightSide item)
+            hasDesc="true"
+            hasRoll="true"
+            description=item.description.value
+        }}
+    {{/ife}} {{/each}}
+
+    {{> 'systems/shadowrun5e/dist/templates/common/List/ListHeader.html'
+            name=(localize 'SR5.Labels.ActorSheet.EnabledOptionSpritePowers')
+            itemId='enabled_option_sprite_power'
+            icons=(ItemHeaderIcons 'sprite_power')
+            rightSide=(ItemHeaderRightSide 'sprite_power')
+    }}
+    {{#each itemType.sprite_power as |item i|}} {{#ife system.optional "enabled_option"}}
+        {{> 'systems/shadowrun5e/dist/templates/common/List/ListItem.html'
+            img=item.img
+            name=item.name
+            itemId=item._id
+            icons=(ItemIcons item)
+            rightSide=(ItemRightSide item)
+            hasDesc="true"
+            hasRoll="true"
+            description=item.description.value
+        }}
+    {{/ife}} {{/each}}
+
+    {{> 'systems/shadowrun5e/dist/templates/common/List/ListHeader.html'
+            name=(localize 'SR5.Labels.ActorSheet.DisabledOptionSpritePowers')
+            itemId='disabled_option_sprite_power'
+            icons=(ItemHeaderIcons 'sprite_power')
+            rightSide=(ItemHeaderRightSide 'sprite_power')
+    }}
+    {{#each itemType.sprite_power as |item i|}} {{#ife system.optional "disabled_option"}}
+        {{> 'systems/shadowrun5e/dist/templates/common/List/ListItem.html'
+            img=item.img
+            name=item.name
+            itemId=item._id
+            icons=(ItemIcons item)
+            rightSide=(ItemRightSide item)
+            hasDesc="true"
+            hasRoll="true"
+            description=item.description.value
+        }}
+    {{/ife}} {{/each}}
 </div>

--- a/src/templates/actor/tabs/CritterPowersTab.html
+++ b/src/templates/actor/tabs/CritterPowersTab.html
@@ -2,12 +2,12 @@
     <div class="inventory">
         <div class="scroll-area">
             {{> 'systems/shadowrun5e/dist/templates/common/List/ListHeader.html'
-                name=(localize "SR5.ItemTypes.CritterPower")
+                name=(localize "SR5.Labels.ActorSheet.CritterPowers")
                 itemId="critter_power"
                 icons=(ItemHeaderIcons "critter_power")
                 rightSide=(ItemHeaderRightSide "critter_power")
             }}
-            {{#each itemType.critter_power as |item i|}} {{#unless system.optional}}
+            {{#each itemType.critter_power as |item i|}} {{#if (or (not system.optional) (eq system.optional "standard"))}}
                 {{> 'systems/shadowrun5e/dist/templates/common/List/ListItem.html'
                     img=item.img
                     name=item.name
@@ -18,29 +18,10 @@
                     hasRoll="true"
                     description=item.description.value
                 }}
-            {{/unless}} {{/each}}
+            {{/if}} {{/each}}
 
             {{> 'systems/shadowrun5e/dist/templates/common/List/ListHeader.html'
-                name=(localize "SR5.ItemTypes.StandardCritterPower")
-                itemId="standard_critter_power"
-                icons=(ItemHeaderIcons "critter_power")
-                rightSide=(ItemHeaderRightSide "critter_power")
-            }}
-            {{#each itemType.critter_power as |item i|}} {{#ife system.optional "standard"}}
-                {{> 'systems/shadowrun5e/dist/templates/common/List/ListItem.html'
-                    img=item.img
-                    name=item.name
-                    itemId=item._id
-                    icons=(ItemIcons item)
-                    rightSide=(ItemRightSide item)
-                    hasDesc="true"
-                    hasRoll="true"
-                    description=item.description.value
-                }}
-            {{/ife}} {{/each}}
-
-            {{> 'systems/shadowrun5e/dist/templates/common/List/ListHeader.html'
-                name=(localize "SR5.ItemTypes.EnabledOptionCritterPower")
+                name=(localize "SR5.Labels.ActorSheet.EnabledOptionCritterPowers")
                 itemId="enabled_option_critter_power"
                 icons=(ItemHeaderIcons "critter_power")
                 rightSide=(ItemHeaderRightSide "critter_power")
@@ -59,7 +40,7 @@
             {{/ife}} {{/each}}
 
             {{> 'systems/shadowrun5e/dist/templates/common/List/ListHeader.html'
-                name=(localize "SR5.ItemTypes.DisabledOptionCritterPower")
+                name=(localize "SR5.Labels.ActorSheet.DisabledOptionCritterPowers")
                 itemId="disabled_option_critter_power"
                 icons=(ItemHeaderIcons "critter_power")
                 rightSide=(ItemHeaderRightSide "critter_power")

--- a/src/templates/actor/tabs/CritterPowersTab.html
+++ b/src/templates/actor/tabs/CritterPowersTab.html
@@ -2,23 +2,80 @@
     <div class="inventory">
         <div class="scroll-area">
             {{> 'systems/shadowrun5e/dist/templates/common/List/ListHeader.html'
-                    name=(localize "SR5.ItemTypes.CritterPower")
-                    itemId="critter_power"
-                    icons=(ItemHeaderIcons "critter_power")
-                    rightSide=(ItemHeaderRightSide "critter_power")
+                name=(localize "SR5.ItemTypes.CritterPower")
+                itemId="critter_power"
+                icons=(ItemHeaderIcons "critter_power")
+                rightSide=(ItemHeaderRightSide "critter_power")
             }}
-            {{#each itemType.critter_power as |item i|}}
+            {{#each itemType.critter_power as |item i|}} {{#unless system.optional}}
                 {{> 'systems/shadowrun5e/dist/templates/common/List/ListItem.html'
-                        img=item.img
-                        name=item.name
-                        itemId=item._id
-                        icons=(ItemIcons item)
-                        rightSide=(ItemRightSide item)
-                        hasDesc="true"
-                        hasRoll="true"
-                        description=item.description.value
+                    img=item.img
+                    name=item.name
+                    itemId=item._id
+                    icons=(ItemIcons item)
+                    rightSide=(ItemRightSide item)
+                    hasDesc="true"
+                    hasRoll="true"
+                    description=item.description.value
                 }}
-            {{/each}}
+            {{/unless}} {{/each}}
+
+            {{> 'systems/shadowrun5e/dist/templates/common/List/ListHeader.html'
+                name=(localize "SR5.ItemTypes.StandardCritterPower")
+                itemId="standard_critter_power"
+                icons=(ItemHeaderIcons "critter_power")
+                rightSide=(ItemHeaderRightSide "critter_power")
+            }}
+            {{#each itemType.critter_power as |item i|}} {{#ife system.optional "standard"}}
+                {{> 'systems/shadowrun5e/dist/templates/common/List/ListItem.html'
+                    img=item.img
+                    name=item.name
+                    itemId=item._id
+                    icons=(ItemIcons item)
+                    rightSide=(ItemRightSide item)
+                    hasDesc="true"
+                    hasRoll="true"
+                    description=item.description.value
+                }}
+            {{/ife}} {{/each}}
+
+            {{> 'systems/shadowrun5e/dist/templates/common/List/ListHeader.html'
+                name=(localize "SR5.ItemTypes.EnabledOptionCritterPower")
+                itemId="enabled_option_critter_power"
+                icons=(ItemHeaderIcons "critter_power")
+                rightSide=(ItemHeaderRightSide "critter_power")
+            }}
+            {{#each itemType.critter_power as |item i|}} {{#ife system.optional "enabled_option"}}
+                {{> 'systems/shadowrun5e/dist/templates/common/List/ListItem.html'
+                    img=item.img
+                    name=item.name
+                    itemId=item._id
+                    icons=(ItemIcons item)
+                    rightSide=(ItemRightSide item)
+                    hasDesc="true"
+                    hasRoll="true"
+                    description=item.description.value
+                }}
+            {{/ife}} {{/each}}
+
+            {{> 'systems/shadowrun5e/dist/templates/common/List/ListHeader.html'
+                name=(localize "SR5.ItemTypes.DisabledOptionCritterPower")
+                itemId="disabled_option_critter_power"
+                icons=(ItemHeaderIcons "critter_power")
+                rightSide=(ItemHeaderRightSide "critter_power")
+            }}
+            {{#each itemType.critter_power as |item i|}} {{#ife system.optional "disabled_option"}}
+                {{> 'systems/shadowrun5e/dist/templates/common/List/ListItem.html'
+                    img=item.img
+                    name=item.name
+                    itemId=item._id
+                    icons=(ItemIcons item)
+                    rightSide=(ItemRightSide item)
+                    hasDesc="true"
+                    hasRoll="true"
+                    description=item.description.value
+                }}
+            {{/ife}} {{/each}}
         </div>
     </div>
 {{/'systems/shadowrun5e/dist/templates/common/TabWrapper.html'}}

--- a/src/templates/item/parts/critter_power.html
+++ b/src/templates/item/parts/critter_power.html
@@ -2,23 +2,12 @@
     <div class="header">
         {{header}}
     </div>
-    <div class="flexrow nowrap">
-        <div class="label form-line">
-            {{localize "SR5.CritterPower.Enabled"}}
-        </div>
-        <input
-        class="checkbox"
-        type="checkbox"
-        name="system.enabled"
-        {{checked
-        system.enabled}}/>
-    </div>
     <div class="form-line">
         <div class="label">
             {{localize "SR5.CritterPower.Optional"}}
         </div>
         <div class="inputs">
-            <select name="system.optional">
+            <select name="system.optional" class="power-optional-input">
                 {{selectOptions config.critterPower.optional selected=system.optional localize=true}}
             </select>
         </div>

--- a/src/templates/item/parts/critter_power.html
+++ b/src/templates/item/parts/critter_power.html
@@ -8,10 +8,7 @@
         </div>
         <div class="inputs">
             <select name="system.powerType">
-                {{#select system.powerType}}
-                    {{#each config.critterPower.types as |name type|}}
-                        <option value="{{type}}">{{localize name}}</option>
-                    {{/each}} {{/select}}
+                {{selectOptions config.critterPower.types selected=system.powerType localize=true}}
             </select>
         </div>
     </div>
@@ -21,9 +18,7 @@
         </div>
         <div class="inputs">
             <select name="system.duration">
-                {{#select system.duration}} {{#each config.critterPower.durations as |name type|}}
-                    <option value="{{type}}">{{localize name}}</option>
-                {{/each}} {{/select}}
+                {{selectOptions config.critterPower.durations selected=system.duration localize=true}}
             </select>
         </div>
     </div>
@@ -33,9 +28,7 @@
         </div>
         <div class="inputs">
             <select name="system.range">
-                {{#select system.range}} {{#each config.critterPower.ranges as |name type|}}
-                    <option value="{{type}}">{{localize name}}</option>
-                {{/each}} {{/select}}
+                {{selectOptions config.critterPower.ranges selected=system.range localize=true}}
             </select>
         </div>
     </div>

--- a/src/templates/item/parts/critter_power.html
+++ b/src/templates/item/parts/critter_power.html
@@ -4,7 +4,7 @@
     </div>
     <div class="form-line">
         <div class="label">
-            {{localize "SR5.CritterPower.Optional"}}
+            {{localize "SR5.CritterPower.IsOptional"}}
         </div>
         <div class="inputs">
             <select name="system.optional" class="power-optional-input">

--- a/src/templates/item/parts/critter_power.html
+++ b/src/templates/item/parts/critter_power.html
@@ -2,6 +2,27 @@
     <div class="header">
         {{header}}
     </div>
+    <div class="flexrow nowrap">
+        <div class="label form-line">
+            {{localize "SR5.CritterPower.Enabled"}}
+        </div>
+        <input
+        class="checkbox"
+        type="checkbox"
+        name="system.enabled"
+        {{checked
+        system.enabled}}/>
+    </div>
+    <div class="form-line">
+        <div class="label">
+            {{localize "SR5.CritterPower.Optional"}}
+        </div>
+        <div class="inputs">
+            <select name="system.optional">
+                {{selectOptions config.critterPower.optional selected=system.optional localize=true}}
+            </select>
+        </div>
+    </div>
     <div class="form-line">
         <div class="label">
             {{localize "SR5.CritterPower.Type"}}

--- a/src/templates/item/sprite_power.html
+++ b/src/templates/item/sprite_power.html
@@ -15,7 +15,7 @@
                     <div class="scroll-area item-form">
                         <div class="form-line">
                             <div class="label">
-                                {{localize "SR5.SpritePower.Optional"}}
+                                {{localize "SR5.SpritePower.IsOptional"}}
                             </div>
                             <div class="inputs">
                                 <select name="system.optional">

--- a/src/templates/item/sprite_power.html
+++ b/src/templates/item/sprite_power.html
@@ -12,7 +12,28 @@
         <div class="tab" data-group="primary" data-tab="sprite_powers">
             <div class="tabbody">
                 <div class="inventory">
-                    <div class="scroll-area">
+                    <div class="scroll-area item-form">
+                        <div class="flexrow nowrap">
+                            <div class="label form-line">
+                                {{localize "SR5.SpritePower.Enabled"}}
+                            </div>
+                            <input
+                            class="checkbox"
+                            type="checkbox"
+                            name="system.enabled"
+                            {{checked
+                            system.enabled}}/>
+                        </div>
+                        <div class="form-line">
+                            <div class="label">
+                                {{localize "SR5.SpritePower.Optional"}}
+                            </div>
+                            <div class="inputs">
+                                <select name="system.optional">
+                                    {{selectOptions config.spritePower.optional selected=system.optional localize=true}}
+                                </select>
+                            </div>
+                        </div>
                         {{> "systems/shadowrun5e/dist/templates/item/parts/action.html" header="Test Details" }}
                         {{> "systems/shadowrun5e/dist/templates/item/parts/damage.html" header="Damage" }}
                         {{>"systems/shadowrun5e/dist/templates/item/parts/opposed.html" header="Opposed Test" }}

--- a/src/templates/item/sprite_power.html
+++ b/src/templates/item/sprite_power.html
@@ -13,17 +13,6 @@
             <div class="tabbody">
                 <div class="inventory">
                     <div class="scroll-area item-form">
-                        <div class="flexrow nowrap">
-                            <div class="label form-line">
-                                {{localize "SR5.SpritePower.Enabled"}}
-                            </div>
-                            <input
-                            class="checkbox"
-                            type="checkbox"
-                            name="system.enabled"
-                            {{checked
-                            system.enabled}}/>
-                        </div>
                         <div class="form-line">
                             <div class="label">
                                 {{localize "SR5.SpritePower.Optional"}}


### PR DESCRIPTION
Fixes #875.

Powers can either be:
- Standard (not optional)
- Optional and enabled
- Optional and disabled

Power tabs now have 3 categories, optional powers can be toggled like an equipment would be equipped.
Disabled powers also disable their effects.