### PR TITLE
[BUG] Blind GM rolls are no longer blind

### DIFF
--- a/src/module/chatMessage/SR5ChatMessage.ts
+++ b/src/module/chatMessage/SR5ChatMessage.ts
@@ -8,15 +8,28 @@ import { TestCreator } from "../tests/TestCreator";
  * If you need to add chat related features, events and listeners you should do so here.
  */
 export class SR5ChatMessage extends ChatMessage {
+    get _testData(): any {
+        return this.getFlag(SYSTEM_NAME, FLAGS.Test);
+    }
     /**
      * Return a SuccessTest implementation for this chat message instance, if there is one.
      */
     get test(): SuccessTest | undefined {
         // Check if message contains any test data.
-        const flagData = this.getFlag(SYSTEM_NAME, FLAGS.Test);
+        const flagData = this._testData;
         if (flagData === null || flagData === undefined) return;
         if (this.id === null || this.id === '') return;
 
         return TestCreator._fromMessageTestData(flagData);
+    }
+
+    /**
+     * Foundry checks by looking at it's rolls, while the system stores those within test data.
+     * 
+     * If no test is imbeded, hand over control to Foundry to still support default roll chat messages
+     * that have been manually or otherwise sent.
+     */
+    override get isRoll(): boolean {
+        return foundry.utils.getType(this._testData) === 'Object' || super.isRoll;
     }
 }


### PR DESCRIPTION
Fixes #1319

This is the new behavior, that matches default Foundry roll messages (except in detail of what's rendered).
![grafik](https://github.com/user-attachments/assets/231e1da4-3fe4-4f45-9be1-419215687a0a)
