### PR TITLE
[BUG] fixed uuid error

### DIFF
--- a/src/module/utils/links.ts
+++ b/src/module/utils/links.ts
@@ -46,8 +46,12 @@ export class LinksHelpers {
     static isUuid(candidate: string | undefined) {
         if (!candidate) return false;
 
-        // @ts-expect-error // parseUuid is not defined in the @league-of-foundry-developers/foundry-vtt-types package
-        return !!foundry.utils.parseUuid(candidate).collection;
+        try {
+            // @ts-expect-error // parseUuid is not defined in the @league-of-foundry-developers/foundry-vtt-types package
+            return !!foundry.utils.parseUuid(candidate).collection;
+          } catch (error) {
+            return false;
+          }
     }
 
     /**


### PR DESCRIPTION
Editing items with an HTML source caused this error:

> foundry.js:655  Error: An error occurred while rendering SR5ItemSheet 43. Invalid number of embedded UUID parts
> [Detected 1 package: system:shadowrun5e(0.24.3)]
>     at Hooks.onError (foundry.js:654:24)
>     at 🎁Hooks.onError#0 (libWrapper-wrapper.js:188:54)
>     at foundry.js:5795:13Caused by: Error: Invalid number of embedded UUID parts
> [Detected 1 package: system:shadowrun5e(0.24.3)]
>     at Object.parseUuid (foundry-esm.js:3571:37)
>     at LinksHelpers.isUuid (links.ts:50:32)
>     at LinksHelpers.isURL (links.ts:32:26)
>     at get sourceIsUrl (SR5Item.ts:925:29)
>     at SR5ItemSheet.getData (SR5ItemSheet.ts:234:38)
>     at async SR5ItemSheet._render (foundry.js:5838:18)
>     at async SR5ItemSheet._render (foundry.js:6572:5)
>     at async SR5ItemSheet._render (foundry.js:7158:5)
>     at async SR5ItemSheet._render (SR5ItemSheet.ts:822:9)

The issue is now handled using a try-catch.