### PR TITLE
2 hooks for Item Events

### DIFF
--- a/src/module/actor/sheets/SR5BaseActorSheet.ts
+++ b/src/module/actor/sheets/SR5BaseActorSheet.ts
@@ -682,12 +682,10 @@ export class SR5BaseActorSheet extends ActorSheet {
         event.preventDefault();
         const iid = Helpers.listItemId(event);
         const item = this.actor.items.get(iid);
-        if (!Hooks.call('SR5_PreActorItemRoll', this.actor, item)) {
-            return;
-        }
-        if (item) {
-            await item.castAction(event);
-        }
+
+        if (!item) return;
+        if (!Hooks.call('SR5_PreActorItemRoll', this.actor, item)) return;
+        await item.castAction(event);
     }
 
     /**

--- a/src/module/actor/sheets/SR5BaseActorSheet.ts
+++ b/src/module/actor/sheets/SR5BaseActorSheet.ts
@@ -682,6 +682,9 @@ export class SR5BaseActorSheet extends ActorSheet {
         event.preventDefault();
         const iid = Helpers.listItemId(event);
         const item = this.actor.items.get(iid);
+        if (!Hooks.call('SR5_PreActorItemRoll', this.actor, item)) {
+            return;
+        }
         if (item) {
             await item.castAction(event);
         }

--- a/src/module/item/SR5Item.ts
+++ b/src/module/item/SR5Item.ts
@@ -289,7 +289,10 @@ export class SR5Item extends Item {
      */
     async castAction(event?: RollEvent) {
         // Only show the item's description by user intention or by lack of testability.
-        const dontRollTest = TestCreator.shouldPostItemDescription(event) || !this.hasRoll;
+        let dontRollTest = TestCreator.shouldPostItemDescription(event);
+        if (Hooks.call('SR5_PreCastItemAction', this)) return;
+        dontRollTest = !this.hasRoll;
+
         if (dontRollTest) return await this.postItemCard();
 
         if (!this.actor) return;

--- a/src/module/item/SR5Item.ts
+++ b/src/module/item/SR5Item.ts
@@ -288,9 +288,10 @@ export class SR5Item extends Item {
      * @param event A PointerEvent by user interaction.
      */
     async castAction(event?: RollEvent) {
+        if (!Hooks.call('SR5_PreCastItemAction', this)) return;
+        
         // Only show the item's description by user intention or by lack of testability.
         let dontRollTest = TestCreator.shouldPostItemDescription(event);
-        if (!Hooks.call('SR5_PreCastItemAction', this)) return;
         dontRollTest = !this.hasRoll;
 
         if (dontRollTest) return await this.postItemCard();

--- a/src/module/item/SR5Item.ts
+++ b/src/module/item/SR5Item.ts
@@ -290,7 +290,7 @@ export class SR5Item extends Item {
     async castAction(event?: RollEvent) {
         // Only show the item's description by user intention or by lack of testability.
         let dontRollTest = TestCreator.shouldPostItemDescription(event);
-        if (Hooks.call('SR5_PreCastItemAction', this)) return;
+        if (!Hooks.call('SR5_PreCastItemAction', this)) return;
         dontRollTest = !this.hasRoll;
 
         if (dontRollTest) return await this.postItemCard();


### PR DESCRIPTION
Defined two hooks for item-events: SR5_PreActorItemRoll and SR5_PreCastItemAction. The first is needed in the upcoming sr-implementation in the [item-macro-module](https://github.com/Foundry-Workshop/Item-Macro/)