### PR TITLE
[Bug Fix] Adding token to combat not working

### DIFF
--- a/src/module/apps/SituationModifiersApplication.ts
+++ b/src/module/apps/SituationModifiersApplication.ts
@@ -449,7 +449,7 @@ export class SituationModifiersApplication extends FormApplication {
         container.append(column);
 
         // Connect SR-FoundryVTT tokenHUD elements to FoundryVTT tokenHUD column structure.
-        html.find('.col.right').after(container);
+        $(html).find('.col.right').after(container);
 
         // Hand DOM element over and let ModifierHandlers add their TokenHUDElements.
         SituationModifiersApplication._staticHandlers.forEach(handler => handler.addTokenHUDElements(column, data._id, actor, modifiers));


### PR DESCRIPTION
1. Select token(s).
2. Right click 
3. Click `Toggle Combat State`.
4. Nothing happens, but a bug: `Error: Error thrown in hooked function 'onRenderTokenHUD' for hook 'renderTokenHUD'. html.find is not a function`