### PR TITLE
[Fix, Dev] Replace deprecated TokenDocument.getActor (removed in V13)

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -28,11 +28,13 @@ module.exports = {
     },
     "plugins": [
         "prettier",
+        "deprecation",
         "@typescript-eslint",
     ],
     parser: '@typescript-eslint/parser',
     "rules": {
         "prettier/prettier": ["off"],
+        "deprecation/deprecation": "warn",
 
         // TODO: ESLint Roadmap Step 2 - Set these rules to "error"
         "@typescript-eslint/no-invalid-void-type": "warn",

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,6 +19,7 @@
                 "eslint": "^8.55.0",
                 "eslint-config-prettier": "^9.1.0",
                 "eslint-config-standard-with-typescript": "^40.0.0",
+                "eslint-plugin-deprecation": "^3.0.0",
                 "eslint-plugin-prettier": "^5.0.1",
                 "events": "^3.3.0",
                 "fs-extra": "^11.1.1",
@@ -4907,6 +4908,199 @@
                 }
             }
         },
+        "node_modules/eslint-plugin-deprecation": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/eslint-plugin-deprecation/-/eslint-plugin-deprecation-3.0.0.tgz",
+            "integrity": "sha512-JuVLdNg/uf0Adjg2tpTyYoYaMbwQNn/c78P1HcccokvhtRphgnRjZDKmhlxbxYptppex03zO76f97DD/yQHv7A==",
+            "dev": true,
+            "license": "LGPL-3.0-or-later",
+            "dependencies": {
+                "@typescript-eslint/utils": "^7.0.0",
+                "ts-api-utils": "^1.3.0",
+                "tslib": "^2.3.1"
+            },
+            "peerDependencies": {
+                "eslint": "^8.0.0",
+                "typescript": "^4.2.4 || ^5.0.0"
+            }
+        },
+        "node_modules/eslint-plugin-deprecation/node_modules/@typescript-eslint/scope-manager": {
+            "version": "7.18.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-7.18.0.tgz",
+            "integrity": "sha512-jjhdIE/FPF2B7Z1uzc6i3oWKbGcHb87Qw7AWj6jmEqNOfDFbJWtjt/XfwCpvNkpGWlcJaog5vTR+VV8+w9JflA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@typescript-eslint/types": "7.18.0",
+                "@typescript-eslint/visitor-keys": "7.18.0"
+            },
+            "engines": {
+                "node": "^18.18.0 || >=20.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/typescript-eslint"
+            }
+        },
+        "node_modules/eslint-plugin-deprecation/node_modules/@typescript-eslint/types": {
+            "version": "7.18.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-7.18.0.tgz",
+            "integrity": "sha512-iZqi+Ds1y4EDYUtlOOC+aUmxnE9xS/yCigkjA7XpTKV6nCBd3Hp/PRGGmdwnfkV2ThMyYldP1wRpm/id99spTQ==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": "^18.18.0 || >=20.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/typescript-eslint"
+            }
+        },
+        "node_modules/eslint-plugin-deprecation/node_modules/@typescript-eslint/typescript-estree": {
+            "version": "7.18.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-7.18.0.tgz",
+            "integrity": "sha512-aP1v/BSPnnyhMHts8cf1qQ6Q1IFwwRvAQGRvBFkWlo3/lH29OXA3Pts+c10nxRxIBrDnoMqzhgdwVe5f2D6OzA==",
+            "dev": true,
+            "license": "BSD-2-Clause",
+            "dependencies": {
+                "@typescript-eslint/types": "7.18.0",
+                "@typescript-eslint/visitor-keys": "7.18.0",
+                "debug": "^4.3.4",
+                "globby": "^11.1.0",
+                "is-glob": "^4.0.3",
+                "minimatch": "^9.0.4",
+                "semver": "^7.6.0",
+                "ts-api-utils": "^1.3.0"
+            },
+            "engines": {
+                "node": "^18.18.0 || >=20.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/typescript-eslint"
+            },
+            "peerDependenciesMeta": {
+                "typescript": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/eslint-plugin-deprecation/node_modules/@typescript-eslint/utils": {
+            "version": "7.18.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-7.18.0.tgz",
+            "integrity": "sha512-kK0/rNa2j74XuHVcoCZxdFBMF+aq/vH83CXAOHieC+2Gis4mF8jJXT5eAfyD3K0sAxtPuwxaIOIOvhwzVDt/kw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@eslint-community/eslint-utils": "^4.4.0",
+                "@typescript-eslint/scope-manager": "7.18.0",
+                "@typescript-eslint/types": "7.18.0",
+                "@typescript-eslint/typescript-estree": "7.18.0"
+            },
+            "engines": {
+                "node": "^18.18.0 || >=20.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/typescript-eslint"
+            },
+            "peerDependencies": {
+                "eslint": "^8.56.0"
+            }
+        },
+        "node_modules/eslint-plugin-deprecation/node_modules/@typescript-eslint/visitor-keys": {
+            "version": "7.18.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-7.18.0.tgz",
+            "integrity": "sha512-cDF0/Gf81QpY3xYyJKDV14Zwdmid5+uuENhjH2EqFaF0ni+yAyq/LzMaIJdhNJXZI7uLzwIlA+V7oWoyn6Curg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@typescript-eslint/types": "7.18.0",
+                "eslint-visitor-keys": "^3.4.3"
+            },
+            "engines": {
+                "node": "^18.18.0 || >=20.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/typescript-eslint"
+            }
+        },
+        "node_modules/eslint-plugin-deprecation/node_modules/brace-expansion": {
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
+            "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "balanced-match": "^1.0.0"
+            }
+        },
+        "node_modules/eslint-plugin-deprecation/node_modules/debug": {
+            "version": "4.4.1",
+            "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.1.tgz",
+            "integrity": "sha512-KcKCqiftBJcZr++7ykoDIEwSa3XWowTfNPo92BYxjXiyYEVrUQh2aLyhxBCwww+heortUFxEJYcRzosstTEBYQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "ms": "^2.1.3"
+            },
+            "engines": {
+                "node": ">=6.0"
+            },
+            "peerDependenciesMeta": {
+                "supports-color": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/eslint-plugin-deprecation/node_modules/globby": {
+            "version": "11.1.0",
+            "resolved": "https://registry.npmjs.org/globby/-/globby-11.1.0.tgz",
+            "integrity": "sha512-jhIXaOzy1sb8IyocaruWSn1TjmnBVs8Ayhcy83rmxNJ8q2uWKCAj3CnJY+KpGSXCueAPc0i05kVvVKtP1t9S3g==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "array-union": "^2.1.0",
+                "dir-glob": "^3.0.1",
+                "fast-glob": "^3.2.9",
+                "ignore": "^5.2.0",
+                "merge2": "^1.4.1",
+                "slash": "^3.0.0"
+            },
+            "engines": {
+                "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/eslint-plugin-deprecation/node_modules/minimatch": {
+            "version": "9.0.5",
+            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
+            "integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
+            "dev": true,
+            "license": "ISC",
+            "dependencies": {
+                "brace-expansion": "^2.0.1"
+            },
+            "engines": {
+                "node": ">=16 || 14 >=14.17"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/isaacs"
+            }
+        },
+        "node_modules/eslint-plugin-deprecation/node_modules/slash": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
+            "integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=8"
+            }
+        },
         "node_modules/eslint-plugin-es-x": {
             "version": "7.5.0",
             "resolved": "https://registry.npmjs.org/eslint-plugin-es-x/-/eslint-plugin-es-x-7.5.0.tgz",
@@ -7045,8 +7239,7 @@
             "version": "2.1.3",
             "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
             "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-            "dev": true,
-            "peer": true
+            "dev": true
         },
         "node_modules/mute-stdout": {
             "version": "2.0.0",
@@ -8191,13 +8384,11 @@
             }
         },
         "node_modules/semver": {
-            "version": "7.5.4",
-            "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
-            "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
+            "version": "7.7.2",
+            "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.2.tgz",
+            "integrity": "sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA==",
             "dev": true,
-            "dependencies": {
-                "lru-cache": "^6.0.0"
-            },
+            "license": "ISC",
             "bin": {
                 "semver": "bin/semver.js"
             },
@@ -8215,18 +8406,6 @@
             },
             "engines": {
                 "node": ">= 10.13.0"
-            }
-        },
-        "node_modules/semver/node_modules/lru-cache": {
-            "version": "6.0.0",
-            "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
-            "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
-            "dev": true,
-            "dependencies": {
-                "yallist": "^4.0.0"
-            },
-            "engines": {
-                "node": ">=10"
             }
         },
         "node_modules/set-function-length": {
@@ -8666,12 +8845,13 @@
             }
         },
         "node_modules/ts-api-utils": {
-            "version": "1.0.3",
-            "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-1.0.3.tgz",
-            "integrity": "sha512-wNMeqtMz5NtwpT/UZGY5alT+VoKdSsOOP/kqHFcUW1P/VRhH2wJ48+DN2WwUliNbQ976ETwDL0Ifd2VVvgonvg==",
+            "version": "1.4.3",
+            "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-1.4.3.tgz",
+            "integrity": "sha512-i3eMG77UTMD0hZhgRS562pv83RC6ukSAC2GMNWc+9dieh/+jDM5u5YG+NHX6VNDRHQcHwmsTHctP9LhbC3WxVw==",
             "dev": true,
+            "license": "MIT",
             "engines": {
-                "node": ">=16.13.0"
+                "node": ">=16"
             },
             "peerDependencies": {
                 "typescript": ">=4.2.0"
@@ -9233,12 +9413,6 @@
             "engines": {
                 "node": ">=10"
             }
-        },
-        "node_modules/yallist": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-            "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
-            "dev": true
         },
         "node_modules/yargs": {
             "version": "17.7.2",
@@ -13206,6 +13380,120 @@
                 "debug": "^3.2.7"
             }
         },
+        "eslint-plugin-deprecation": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/eslint-plugin-deprecation/-/eslint-plugin-deprecation-3.0.0.tgz",
+            "integrity": "sha512-JuVLdNg/uf0Adjg2tpTyYoYaMbwQNn/c78P1HcccokvhtRphgnRjZDKmhlxbxYptppex03zO76f97DD/yQHv7A==",
+            "dev": true,
+            "requires": {
+                "@typescript-eslint/utils": "^7.0.0",
+                "ts-api-utils": "^1.3.0",
+                "tslib": "^2.3.1"
+            },
+            "dependencies": {
+                "@typescript-eslint/scope-manager": {
+                    "version": "7.18.0",
+                    "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-7.18.0.tgz",
+                    "integrity": "sha512-jjhdIE/FPF2B7Z1uzc6i3oWKbGcHb87Qw7AWj6jmEqNOfDFbJWtjt/XfwCpvNkpGWlcJaog5vTR+VV8+w9JflA==",
+                    "dev": true,
+                    "requires": {
+                        "@typescript-eslint/types": "7.18.0",
+                        "@typescript-eslint/visitor-keys": "7.18.0"
+                    }
+                },
+                "@typescript-eslint/types": {
+                    "version": "7.18.0",
+                    "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-7.18.0.tgz",
+                    "integrity": "sha512-iZqi+Ds1y4EDYUtlOOC+aUmxnE9xS/yCigkjA7XpTKV6nCBd3Hp/PRGGmdwnfkV2ThMyYldP1wRpm/id99spTQ==",
+                    "dev": true
+                },
+                "@typescript-eslint/typescript-estree": {
+                    "version": "7.18.0",
+                    "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-7.18.0.tgz",
+                    "integrity": "sha512-aP1v/BSPnnyhMHts8cf1qQ6Q1IFwwRvAQGRvBFkWlo3/lH29OXA3Pts+c10nxRxIBrDnoMqzhgdwVe5f2D6OzA==",
+                    "dev": true,
+                    "requires": {
+                        "@typescript-eslint/types": "7.18.0",
+                        "@typescript-eslint/visitor-keys": "7.18.0",
+                        "debug": "^4.3.4",
+                        "globby": "^11.1.0",
+                        "is-glob": "^4.0.3",
+                        "minimatch": "^9.0.4",
+                        "semver": "^7.6.0",
+                        "ts-api-utils": "^1.3.0"
+                    }
+                },
+                "@typescript-eslint/utils": {
+                    "version": "7.18.0",
+                    "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-7.18.0.tgz",
+                    "integrity": "sha512-kK0/rNa2j74XuHVcoCZxdFBMF+aq/vH83CXAOHieC+2Gis4mF8jJXT5eAfyD3K0sAxtPuwxaIOIOvhwzVDt/kw==",
+                    "dev": true,
+                    "requires": {
+                        "@eslint-community/eslint-utils": "^4.4.0",
+                        "@typescript-eslint/scope-manager": "7.18.0",
+                        "@typescript-eslint/types": "7.18.0",
+                        "@typescript-eslint/typescript-estree": "7.18.0"
+                    }
+                },
+                "@typescript-eslint/visitor-keys": {
+                    "version": "7.18.0",
+                    "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-7.18.0.tgz",
+                    "integrity": "sha512-cDF0/Gf81QpY3xYyJKDV14Zwdmid5+uuENhjH2EqFaF0ni+yAyq/LzMaIJdhNJXZI7uLzwIlA+V7oWoyn6Curg==",
+                    "dev": true,
+                    "requires": {
+                        "@typescript-eslint/types": "7.18.0",
+                        "eslint-visitor-keys": "^3.4.3"
+                    }
+                },
+                "brace-expansion": {
+                    "version": "2.0.2",
+                    "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
+                    "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
+                    "dev": true,
+                    "requires": {
+                        "balanced-match": "^1.0.0"
+                    }
+                },
+                "debug": {
+                    "version": "4.4.1",
+                    "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.1.tgz",
+                    "integrity": "sha512-KcKCqiftBJcZr++7ykoDIEwSa3XWowTfNPo92BYxjXiyYEVrUQh2aLyhxBCwww+heortUFxEJYcRzosstTEBYQ==",
+                    "dev": true,
+                    "requires": {
+                        "ms": "^2.1.3"
+                    }
+                },
+                "globby": {
+                    "version": "11.1.0",
+                    "resolved": "https://registry.npmjs.org/globby/-/globby-11.1.0.tgz",
+                    "integrity": "sha512-jhIXaOzy1sb8IyocaruWSn1TjmnBVs8Ayhcy83rmxNJ8q2uWKCAj3CnJY+KpGSXCueAPc0i05kVvVKtP1t9S3g==",
+                    "dev": true,
+                    "requires": {
+                        "array-union": "^2.1.0",
+                        "dir-glob": "^3.0.1",
+                        "fast-glob": "^3.2.9",
+                        "ignore": "^5.2.0",
+                        "merge2": "^1.4.1",
+                        "slash": "^3.0.0"
+                    }
+                },
+                "minimatch": {
+                    "version": "9.0.5",
+                    "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
+                    "integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
+                    "dev": true,
+                    "requires": {
+                        "brace-expansion": "^2.0.1"
+                    }
+                },
+                "slash": {
+                    "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
+                    "integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==",
+                    "dev": true
+                }
+            }
+        },
         "eslint-plugin-es-x": {
             "version": "7.5.0",
             "resolved": "https://registry.npmjs.org/eslint-plugin-es-x/-/eslint-plugin-es-x-7.5.0.tgz",
@@ -14662,8 +14950,7 @@
             "version": "2.1.3",
             "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
             "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-            "dev": true,
-            "peer": true
+            "dev": true
         },
         "mute-stdout": {
             "version": "2.0.0",
@@ -15526,24 +15813,10 @@
             }
         },
         "semver": {
-            "version": "7.5.4",
-            "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
-            "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
-            "dev": true,
-            "requires": {
-                "lru-cache": "^6.0.0"
-            },
-            "dependencies": {
-                "lru-cache": {
-                    "version": "6.0.0",
-                    "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
-                    "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
-                    "dev": true,
-                    "requires": {
-                        "yallist": "^4.0.0"
-                    }
-                }
-            }
+            "version": "7.7.2",
+            "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.2.tgz",
+            "integrity": "sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA==",
+            "dev": true
         },
         "semver-greatest-satisfied-range": {
             "version": "2.0.0",
@@ -15892,9 +16165,9 @@
             }
         },
         "ts-api-utils": {
-            "version": "1.0.3",
-            "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-1.0.3.tgz",
-            "integrity": "sha512-wNMeqtMz5NtwpT/UZGY5alT+VoKdSsOOP/kqHFcUW1P/VRhH2wJ48+DN2WwUliNbQ976ETwDL0Ifd2VVvgonvg==",
+            "version": "1.4.3",
+            "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-1.4.3.tgz",
+            "integrity": "sha512-i3eMG77UTMD0hZhgRS562pv83RC6ukSAC2GMNWc+9dieh/+jDM5u5YG+NHX6VNDRHQcHwmsTHctP9LhbC3WxVw==",
             "dev": true,
             "requires": {}
         },
@@ -16320,12 +16593,6 @@
             "version": "5.0.8",
             "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
             "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
-            "dev": true
-        },
-        "yallist": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-            "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
             "dev": true
         },
         "yargs": {

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
         "eslint": "^8.55.0",
         "eslint-config-prettier": "^9.1.0",
         "eslint-config-standard-with-typescript": "^40.0.0",
+        "eslint-plugin-deprecation": "^3.0.0",
         "eslint-plugin-prettier": "^5.0.1",
         "events": "^3.3.0",
         "fs-extra": "^11.1.1",

--- a/src/module/helpers.ts
+++ b/src/module/helpers.ts
@@ -325,7 +325,7 @@ export class Helpers {
         const [sceneId, tokenId] = Helpers.deconstructSceneTokenId(sceneTokenId);
         const token = Helpers.getSceneTokenDocument(sceneId, tokenId);
         if (!token) return null;
-        return token.getActor();
+        return token.actor;
     }
 
     static deconstructSceneTokenId(sceneTokenId: string): [sceneId: string, tokenId: string] {


### PR DESCRIPTION
Fixed usage of the deprecated `TokenDocument.getActor()` method, which was removed in Foundry VTT v13, replacing it with `TokenDocument.actor`. Also added `eslint-plugin-deprecation` to the project to automatically catch deprecated API usage during development.