### PR TITLE
[BUG] Spirit Sheet shows unuseable value 'Base' input

### DIFF
--- a/src/templates/actor/parts/attributes/FakeAttribute.html
+++ b/src/templates/actor/parts/attributes/FakeAttribute.html
@@ -1,3 +1,4 @@
+{{#if attribute}}
 {{#> "systems/shadowrun5e/dist/templates/common/Attribute.html" dataName="attribute" dataId=attributeId}}
     <div class="attribute-name roll {{#if rollId}}Roll{{/if}}">
         {{#if label}}
@@ -34,3 +35,4 @@
         </div> -->
     </div>
 {{/"systems/shadowrun5e/dist/templates/common/Attribute.html"}}
+{{/if}}


### PR DESCRIPTION

Characters have the initiation attribute set, while spirits don´t. The FakeAttribute helper still tries showing an attribute, even if it doesn't exist.

Fixes #1423