### PR TITLE
[Fix] getToken not working when linked token exist but is not default

### DIFF
--- a/src/module/actor/SR5Actor.ts
+++ b/src/module/actor/SR5Actor.ts
@@ -1282,27 +1282,23 @@ export class SR5Actor extends Actor {
     /**
      * Returns the most appropriate token document for the actor.
      *
-     * The method prioritizes:
-     * 1. A currently selected (controlled) token on the canvas that belongs to this actor.
-     * 2. A linked token on the canvas (if the actor is linked).
-     * 3. The actor’s stored token reference, if available (may be null).
+     * Priority:
+     * 1. Synthetic token (if this actor is synthetic).
+     * 2. A controlled linked token on the canvas.
+     * 3. Any linked token on the canvas.
+     * 4. Null if no token is available.
      *
      * @returns The token document if available, otherwise null.
      */
     getToken(): TokenDocument | null {
-        // Priority 1: Return a controlled token that belongs to this actor.
-        const controlledTokens = canvas.tokens?.controlled;
-        if (controlledTokens) {
-            const owned = this.getActiveTokens().find(t => controlledTokens.includes(t));
-            if (owned) return owned.document;
-        }
+        // 1. this is a synthetic actor, return its token.
+        if (this.token) return this.token;
 
-        // Priority 2: Look for a linked token (unique for linked actors).
-        const linked = this.getActiveTokens(true);
-        if (linked.length > 0) return linked[0].document;
+        const linkedTokens = this.getActiveTokens(true);
+        const controlled = canvas.tokens?.controlled?.find(t => linkedTokens.includes(t));
 
-        // Priority 3: Fallback to the actor's assigned token reference.
-        return this.token;
+        // controlled & linked -> linked
+        return controlled?.document ?? linkedTokens[0]?.document ?? null;
     }
 
     hasActivePlayerOwner(): boolean {

--- a/src/module/actor/SR5Actor.ts
+++ b/src/module/actor/SR5Actor.ts
@@ -1279,34 +1279,27 @@ export class SR5Actor extends Actor {
         return Helpers.onGetFlag(data);
     }
 
-    /** Return either the linked token or the token of the synthetic actor.
+    /**
+     * Returns the most appropriate token document for the actor.
      *
-     * @return Will return null should no token have been placed on scene.
+     * The method prioritizes:
+     * 1. A linked token on the canvas.
+     * 2. A unlinked token on the canvas.
+     * 3. Fallback to the actor's own assigned token reference (maybe null).
+     *
+     * @returns The token document if available, otherwise null.
      */
     getToken(): TokenDocument | null {
-        // Linked actors can only have one token, which isn't stored within actor data...
-        if (this._isLinkedToToken() && this.hasToken()) {
-            const linked = true;
-            const tokens = this.getActiveTokens(linked) as unknown as Token[];
-            // This assumes for a token to exist and should fail if not.
-            return tokens[0].document;
-        }
+        // Try to find a linked token first.
+        const linked = this.getActiveTokens(true);
+        if (linked.length > 0) return linked[0].document;
 
-        // Unlinked actors can have multiple active token but each have theirs directly attached...
+        // Fallback to unlinked tokens.
+        const unlinked = this.getActiveTokens(false);
+        if (unlinked.length > 0) return unlinked[0].document;
+
+        // Fallback to use the actor's stored token reference (maybe null).
         return this.token;
-    }
-
-    /**
-     * There is no need for a token to placed. The prototype token is enough.
-     */
-    _isLinkedToToken(): boolean {
-        //@ts-expect-error // TODO: foundry-vtt-types v10
-        // If an actor is linked, all it's copies also contain this linked status, even if they're not.
-        return this.prototypeToken.actorLink && !this.token;
-    }
-
-    hasToken(): boolean {
-        return this.getActiveTokens().length > 0;
     }
 
     hasActivePlayerOwner(): boolean {

--- a/src/module/actor/SR5Actor.ts
+++ b/src/module/actor/SR5Actor.ts
@@ -1283,22 +1283,25 @@ export class SR5Actor extends Actor {
      * Returns the most appropriate token document for the actor.
      *
      * The method prioritizes:
-     * 1. A linked token on the canvas.
-     * 2. A unlinked token on the canvas.
-     * 3. Fallback to the actor's own assigned token reference (maybe null).
+     * 1. A currently selected (controlled) token on the canvas that belongs to this actor.
+     * 2. A linked token on the canvas (if the actor is linked).
+     * 3. The actor’s stored token reference, if available (may be null).
      *
      * @returns The token document if available, otherwise null.
      */
     getToken(): TokenDocument | null {
-        // Try to find a linked token first.
+        // Priority 1: Return a controlled token that belongs to this actor.
+        const controlledTokens = canvas.tokens?.controlled;
+        if (controlledTokens) {
+            const owned = this.getActiveTokens().find(t => controlledTokens.includes(t));
+            if (owned) return owned.document;
+        }
+
+        // Priority 2: Look for a linked token (unique for linked actors).
         const linked = this.getActiveTokens(true);
         if (linked.length > 0) return linked[0].document;
 
-        // Fallback to unlinked tokens.
-        const unlinked = this.getActiveTokens(false);
-        if (unlinked.length > 0) return unlinked[0].document;
-
-        // Fallback to use the actor's stored token reference (maybe null).
+        // Priority 3: Fallback to the actor's assigned token reference.
         return this.token;
     }
 


### PR DESCRIPTION
Refactor `getToken` into:
```js
/**
 * Returns the most appropriate token document for the actor.
 *
 * Priority:
 * 1. Synthetic token (if this actor is synthetic).
 * 2. A controlled linked token on the canvas.
 * 3. Any linked token on the canvas.
 * 4. Null if no token is available.
 *
 * @returns The token document if available, otherwise null.
 */
 ```