### PR TITLE
[Code] Fix Inconsistent EOL Settings to Preserve Git History

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -5,7 +5,7 @@
     "quoteProps": "consistent",
     "trailingComma": "all",
     "bracketSpacing": true,
-    "endOfLine": "crlf",
+    "endOfLine": "lf",
     "printWidth": 120,
     "semi": true
 }


### PR DESCRIPTION
All files currently use `'lf'` as the end-of-line character, as confirmed: [here in Discord](https://discord.com/channels/170995199584108546/715689255606681660/1392863695843098727) by [MatyeusM](https://github.com/MatyeusM).

However, the current incorrect configuration can cause every line in a file to appear changed unnecessarily, breaking `git blame` functionality. This issue is demonstrated in: https://github.com/SR5-FoundryVTT/SR5-FoundryVTT/commit/43f19b8dbd7d7e755c7ca169de186f3280b67116.

Therefore, I recommend enforcing `'lf'` as the standard end-of-line setting to maintain consistent file formatting and accurate version history tracking.