### PR TITLE
[Code] Add path alias support for TypeScript imports

### DIFF
--- a/gulp.tasks.js
+++ b/gulp.tasks.js
@@ -3,6 +3,7 @@ const fs = require('fs-extra');
 const path = require('path');
 const del = import('del'); //es6m
 const chalk = import('chalk'); //es6m
+const tsPaths = require("esbuild-ts-paths")
 
 // Sass
 const gulpsass = require('gulp-sass')(require('sass'));
@@ -48,7 +49,7 @@ async function buildJS() {
         format: 'esm',
         outfile: path.resolve(destFolder, jsBundle),
         // Don't typescheck on build. Instead typecheck on PR and push and assume releases to build.
-        plugins: [],
+        plugins: [tsPaths()],
     }).catch((err) => {
         console.error(err)
     })
@@ -89,7 +90,7 @@ async function watch() {
             outfile: path.resolve(destFolder, jsBundle),
             plugins: [typecheckPlugin({watch: true})],
       })
-      
+
       // Enable watch mode
       await context.watch();
 }
@@ -110,10 +111,10 @@ async function buildSass() {
 /**
  * FoundryVTT compendium/packs.
  * Create all needed packs from their source files.
- * 
+ *
  * Since gulp tasks uses a commonJS file, while pack uses a es6 module, we have to use the node execution of packs.
- * 
- * Rebuilding packs.mjs to be commonJS as well, would mean to deviate from the dnd5e source of it, which I avoid to 
+ *
+ * Rebuilding packs.mjs to be commonJS as well, would mean to deviate from the dnd5e source of it, which I avoid to
  * keep future changes on their side easier to merge.
  */
 async function buildPacks() {

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,7 @@
                 "chalk": "^5.3.0",
                 "del": "^7.1.0",
                 "esbuild": "^0.25.0",
+                "esbuild-ts-paths": "^1.1.3",
                 "eslint": "^8.55.0",
                 "eslint-config-prettier": "^9.1.0",
                 "eslint-config-standard-with-typescript": "^40.0.0",
@@ -4730,6 +4731,17 @@
                 "@esbuild/win32-arm64": "0.25.0",
                 "@esbuild/win32-ia32": "0.25.0",
                 "@esbuild/win32-x64": "0.25.0"
+            }
+        },
+        "node_modules/esbuild-ts-paths": {
+            "version": "1.1.3",
+            "resolved": "https://registry.npmjs.org/esbuild-ts-paths/-/esbuild-ts-paths-1.1.3.tgz",
+            "integrity": "sha512-qV8WVCcMhQplEfqeu1VPa7llPL9NXpEES275z8z3FHhrescVKNzLSawGOINpmPTYo+WFUiKKLwSFcM0JoQQ5eg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "fast-glob": "^3.2.11",
+                "normalize-path": "^3.0.0"
             }
         },
         "node_modules/escalade": {
@@ -13181,6 +13193,16 @@
                 "@esbuild/win32-arm64": "0.25.0",
                 "@esbuild/win32-ia32": "0.25.0",
                 "@esbuild/win32-x64": "0.25.0"
+            }
+        },
+        "esbuild-ts-paths": {
+            "version": "1.1.3",
+            "resolved": "https://registry.npmjs.org/esbuild-ts-paths/-/esbuild-ts-paths-1.1.3.tgz",
+            "integrity": "sha512-qV8WVCcMhQplEfqeu1VPa7llPL9NXpEES275z8z3FHhrescVKNzLSawGOINpmPTYo+WFUiKKLwSFcM0JoQQ5eg==",
+            "dev": true,
+            "requires": {
+                "fast-glob": "^3.2.11",
+                "normalize-path": "^3.0.0"
             }
         },
         "escalade": {

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
         "chalk": "^5.3.0",
         "del": "^7.1.0",
         "esbuild": "^0.25.0",
+        "esbuild-ts-paths": "^1.1.3",
         "eslint": "^8.55.0",
         "eslint-config-prettier": "^9.1.0",
         "eslint-config-standard-with-typescript": "^40.0.0",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,21 +1,19 @@
 {
-  "include": [
-    "src/**/*",
-    "src/module/types/global.d.ts"
-  ],
-  "exclude": ["node_modules", "**/*.spec.ts"],
-  "compilerOptions": {
-    "target": "es6",
-    "module": "commonjs",
-    "types": [
-      "@league-of-foundry-developers/foundry-vtt-types",
-      "@ethaks/fvtt-quench"
-    ],
-    "moduleResolution": "node",
-    "strictNullChecks": true,
-    "skipLibCheck": true,
-    "noEmitOnError": false,
-    "noImplicitOverride": true,
-    "resolveJsonModule": true
-  }
+    "include": ["src/**/*", "src/module/types/global.d.ts"],
+    "exclude": ["node_modules", "**/*.spec.ts"],
+    "compilerOptions": {
+        "target": "es6",
+        "module": "commonjs",
+        "types": ["@league-of-foundry-developers/foundry-vtt-types", "@ethaks/fvtt-quench"],
+        "moduleResolution": "node",
+        "strictNullChecks": true,
+        "skipLibCheck": true,
+        "noEmitOnError": false,
+        "noImplicitOverride": true,
+        "resolveJsonModule": true,
+        "paths": {
+            "baseUrl": ["."],
+            "@/*": ["./src/*"]
+        }
+    }
 }


### PR DESCRIPTION
This PR adds support for path aliasing using `@`, currently configured to point to the `src/` folder. This allows us to replace deep relative imports like `../../hooks` with cleaner, absolute-style imports such as `@/module/hooks`.

While this PR doesn't yet refactor existing imports to use the alias (to avoid conflicts with upcoming large PRs), it lays the groundwork for doing so in the future. We may also consider adjusting the alias to point directly to `src/module` instead, which would enable imports like `@/hooks`.

This should help reduce header clutter and improve code readability going forward. I am sorry, I know hooks is a bad example; but you get what i mean.