### PR TITLE
[Fix] Character considered dead if overflow.max = 0;

### DIFF
--- a/src/module/rules/ConditionRules.ts
+++ b/src/module/rules/ConditionRules.ts
@@ -14,7 +14,7 @@ export const ConditionRules = {
      */
     determineDefeatedStatus: (actor: SR5Actor): DefeatedStatus => {
         const stun = actor.getStunTrack();
-        const phyiscal = actor.getPhysicalTrack();
+        const physical = actor.getPhysicalTrack();
         const matrix = actor.getMatrixTrack();
 
         let unconscious = false;
@@ -25,11 +25,11 @@ export const ConditionRules = {
         if (actor.isIC() || actor.isSprite()) {
             dead = matrix?.value === matrix?.max;
         } else if (actor.isVehicle() || actor.isGrunt()) {
-            dead = phyiscal?.value === phyiscal?.max;
+            dead = physical?.value === physical?.max;
         } else {
             unconscious = stun?.value === stun?.max;
-            dying = phyiscal?.value === phyiscal?.max;
-            dead = phyiscal?.overflow.value === phyiscal?.overflow.max;
+            dying = physical?.value === physical?.max;
+            dead = dying && physical?.overflow.value === physical?.overflow.max;
         }
 
         return {


### PR DESCRIPTION
Basically, it fixes a bug when:

1. Create a new actor (drag into scene to visually see it)
   - `Body` value will be at 0.
2. Change any track value
3. The token will be shown as dead.

So, in addition to check whether the overflow is full, it checks whether physical track is also full.