### PR TITLE
[Bug] Fix active effects on critter powers applying when disabled

### DIFF
--- a/src/module/data/SR5ItemDataWrapper.ts
+++ b/src/module/data/SR5ItemDataWrapper.ts
@@ -208,12 +208,12 @@ export class SR5ItemDataWrapper extends DataWrapper<ShadowrunItemData> {
     }
 
     isEnabled(): boolean {
-        if(!this.isCritterPower && !this.isSpritePower) return false;
+        if(!this.isCritterPower() && !this.isSpritePower()) return false;
         return this.getData().enabled !== undefined ? this.getData().enabled === true : true;
     }
 
     canBeDisabled(): boolean {
-        if(!this.isCritterPower && !this.isSpritePower) return false;
+        if(!this.isCritterPower() && !this.isSpritePower()) return false;
         return (this.getData().optional || 'standard') !== 'standard'
     }
 


### PR DESCRIPTION
This fixes critter and sprite power active effects to not apply when the power isn't enabled