### PR TITLE
[BUG] German Locale: Sprite sheet condition monitor cutting of label 'Zustandsm(onitor)'

### DIFF
--- a/src/templates/actor/sprite.html
+++ b/src/templates/actor/sprite.html
@@ -14,7 +14,7 @@
                             value=system.matrix.condition_monitor.value
                             max=system.matrix.condition_monitor.max
                             id="matrix"
-                            name=(localize "SR5.ConditionMonitor")
+                            name=(localize "SR5.DmgTypeMatrix")
                     }}
                 </div>
             </div>


### PR DESCRIPTION
Fixes #1461