### PR TITLE
[Layout] Correct wrong use of flex styling causing need for fixed heights on scroll areas

### DIFF
--- a/src/css/actor.scss
+++ b/src/css/actor.scss
@@ -264,3 +264,8 @@
         overflow: hidden;
     }
 }
+
+.sr5 .flexcol-skills {
+    display: flex;
+    flex-direction: column;
+}

--- a/src/css/bundle.scss
+++ b/src/css/bundle.scss
@@ -603,10 +603,6 @@ input[type='text'].display {
         flex: 1;
         overflow-y: auto;
         overflow-x: hidden;
-        // This is a hack due to broken flex / grid styling on the current sheet, making fixed heights necessary for scroll bars.
-        // Raising this above 300px (remaining sheet height on default sheet dimension), will break scroll behavior
-        // on default dimensions
-        max-height: 300px;
         min-height: 0;
     }
 


### PR DESCRIPTION
Fix #1472 by fixing the flex-layout instead of hacking a height.