### PR TITLE
[Layout] Vertically center text in list-items in lists

### DIFF
--- a/src/css/bundle.scss
+++ b/src/css/bundle.scss
@@ -942,6 +942,12 @@ input[type='text'].display {
             align-items: center;
             align-content: center;
 
+            // vertically center the rows, using a table would have
+            // been better, but i pray for V2 or during the rework.
+            &:not(.list-header > .list-item-content) {
+              margin-top: 0.3125rem;
+            }
+
             .item-center {
                 display: flex;
                 flex-flow: row nowrap;


### PR DESCRIPTION
Before:

<img width="445" height="324" alt="image" src="https://github.com/user-attachments/assets/1f74c3f1-201d-49a9-b0e1-d05541af2659" />

After (excuse me for the color difference, it is from the scss branch):

<img width="452" height="329" alt="image" src="https://github.com/user-attachments/assets/8514d433-5418-4351-8554-68c3fd60a0b3" />
