### PR TITLE
[Bug] ActiveEffect change mode ADD breaks sheets when applied directly on ModifiableField. Redirect add on such direct / indirect keys to modify.

### DIFF
--- a/src/module/effect/SR5ActiveEffect.ts
+++ b/src/module/effect/SR5ActiveEffect.ts
@@ -162,8 +162,8 @@ export class SR5ActiveEffect extends ActiveEffect {
     }
 
     /**
-     * Avoid missuse of some mods to break sheet rendering. Specifically due to modify and override special
-     * handling of ModifiableField, we should save users from using mode Add wrong by adressing a ModifiableField
+     * Avoid misuse of some mods to break sheet rendering. Specifically due to modify and override special
+     * handling of ModifiableField, we should save users from using mode Add wrong by addressing a ModifiableField
      * change key directly, therefore breaking sheet rendering.
      * 
      * @param model The model used to check value types under key

--- a/src/module/types/fields/ModifiableField.ts
+++ b/src/module/types/fields/ModifiableField.ts
@@ -9,12 +9,11 @@ import SchemaField = foundry.data.fields.SchemaField;
  * A ModifiableSchemaField is a SchemaField that represents a ModifiableValue type, which 
  * holds further system functionality.
  * 
- * A ModifiableValue holds att least these properties:
- * - base
- * - value
- * - mod
- * - override
- * - temp
+ * Foundry will hand over authority over applying value changes to SchemaFields, when the document
+ * is using a DataModel schema.
+ * 
+ * ModifiableField alteres default Foundry mode behavior to allow the system to show the whole 
+ * value resolution instead of just altering the total modified value.
  */
 export class ModifiableField<
     Fields extends ReturnType<typeof ModifiableValue>,
@@ -27,11 +26,8 @@ export class ModifiableField<
     >
 > extends foundry.data.fields.SchemaField<Fields, Options, AssignmentType, InitializedType, PersistedType> {
     /**
-     * When applying a effect change, inject custom application logic for ModifiableValues.
+     * Foundries custom mode is the systems Modify mode.
      *
-     * Modify will inject into custom data, when system ModifiableValue-fields are found, which will later be used for
-     * value transparancy and calcution. .
-     * 
      * @param value 
      * @param delta 
      * @param model 
@@ -44,10 +40,8 @@ export class ModifiableField<
     }
 
     /**
-     * When applying a effect change, inject custom application logic for ModifiableValues.
-     * 
-     * Override will create custom data, when system ModifiableValue-fields are found, which will late be used for
-     * value transparancy and calculation.
+     * Foundries override mode is extended by the system to allow for transparent display of both the
+     * original value and the new, overriden, value.
      * 
      * @param value 
      * @param delta 

--- a/src/unittests/sr5.ActiveEffect.spec.ts
+++ b/src/unittests/sr5.ActiveEffect.spec.ts
@@ -140,7 +140,7 @@ export const shadowrunSR5ActiveEffect = (context: QuenchBatchContext) => {
             });
         });
 
-        it('ADD mode: adding to ModifableField should cause MODIFY mode to be used', async () => {
+        it('ADD mode: adding to ModifiableField should cause MODIFY mode to be used', async () => {
             const actor = await factory.createActor({ type: 'character' });
 
             assert.strictEqual(actor.system.attributes.body.value, 0);

--- a/src/unittests/sr5.ActiveEffect.spec.ts
+++ b/src/unittests/sr5.ActiveEffect.spec.ts
@@ -15,7 +15,6 @@ export const shadowrunSR5ActiveEffect = (context: QuenchBatchContext) => {
 
     after(async () => { factory.destroy(); });
 
-    // TODO: taMiF Effects application of MODIFY (at least) is broken. We might have to fully replace ActiveEffect.apply()
     describe('SR5ActiveEffect', () => {
         it('MODIFY mode: apply system custom mode to main and sub value-keys', async () => {
             const actor = await factory.createActor({ type: 'character' });
@@ -141,6 +140,27 @@ export const shadowrunSR5ActiveEffect = (context: QuenchBatchContext) => {
             });
         });
 
+        it('ADD mode: adding to ModifableField should cause MODIFY mode to be used', async () => {
+            const actor = await factory.createActor({ type: 'character' });
+
+            assert.strictEqual(actor.system.attributes.body.value, 0);
+            assert.strictEqual(actor.system.skills.active.automatics.value, 0);
+
+            await actor.createEmbeddedDocuments('ActiveEffect', [{
+                origin: actor.uuid,
+                disabled: false,
+                name: 'Test Effect',
+                changes: [
+                    { key: 'system.attributes.body', value: '3', mode: CONST.ACTIVE_EFFECT_MODES.ADD },
+                    { key: 'system.skills.active.automatics', value: '3', mode: CONST.ACTIVE_EFFECT_MODES.ADD }
+                ]
+            }]);
+
+            assert.strictEqual(actor.system.attributes.body.value, 3);
+            assert.deepEqual(actor.system.attributes.body.mod, [{ name: 'Test Effect', value: 3 }]);
+            assert.strictEqual(actor.system.skills.active.automatics.value, 3);
+            assert.deepEqual(actor.system.skills.active.automatics.mod, [{ name: 'Test Effect', value: 3 }]);
+        });
     });
     /**
  * Tests around the systems 'advanced' effects on top of Foundry core active effects.


### PR DESCRIPTION
This will alter effect change modes when the add mode is applied to a ModifiableField, either direct or indirect.

I don't see a use case for Add on those fields, and even if only .base would be a good idea. So just apply Add as modify on those.

Changes made in this PR to previous behavior:
- [Feature] Add mode works like Modify mode. When addressing a value (attribute, skill, limit) it will apply the change value to the modify chain. For that the change key can either directly address the value (`system.attributes.body`) or indirectly with any of its properties used for calculation (`system.attributes.body.value`, `.base`, `.mod`, `.temp`).