### PR TITLE
[Feature] Reconnect on last used grid when disconnecting / deleting host mark

### DIFF
--- a/src/module/actor/SR5Actor.ts
+++ b/src/module/actor/SR5Actor.ts
@@ -700,14 +700,10 @@ export class SR5Actor<SubType extends Actor.ConfiguredSubType = Actor.Configured
      * @param network Must be an item of matching type
      */
     async connectNetwork(network: SR5Item) {
-        // General connection handling.
         await MatrixNetworkFlow.addSlave(network, this);
 
-        // Actor type specific connection handling.
-        switch (this.type) {
-            case 'ic':
-                await MatrixICFlow.connectToHost(network, this);
-                break;
+        if (this.isType('ic')) {
+            await MatrixICFlow.connectToHost(network, this);
         }
     }
 

--- a/src/module/actor/flows/MatrixICFlow.ts
+++ b/src/module/actor/flows/MatrixICFlow.ts
@@ -16,7 +16,6 @@ export const MatrixICFlow = {
     async connectToHost(host: SR5Item, ic: SR5Actor) {
         // Allow call to drop out gracefully.
         if (!ic.isType('ic')) return;
-        // TODO: foundry-vtt-types v9
         const hostData = host.asType('host');
         if (!hostData) return;
 

--- a/src/module/item/flows/MatrixNetworkFlow.ts
+++ b/src/module/item/flows/MatrixNetworkFlow.ts
@@ -231,7 +231,7 @@ export class MatrixNetworkFlow {
      * Reconnect a matrix actor to its last used grid after disconnecting from a host.
      * 
      * @param slave The matrix actor to reconnect.
-     * @param master A possible grid already connected to.
+     * @param master The item (typically a host) the actor is being disconnected from.
      */
     static async reconnectToLastGrid(slave: SR5Actor, master: SR5Item) {
         // Let users disconnect from grids only.
@@ -240,9 +240,9 @@ export class MatrixNetworkFlow {
         if (!slave.isMatrixActor) return;
 
         const matrixData = slave.matrixData();
-        if (!matrixData?.grid) return;
+        if (!matrixData?.grid.uuid) return;
 
-        const grid = foundry.utils.fromUuidSync(matrixData.grid) as SR5Item<'grid'> | undefined;
+        const grid = foundry.utils.fromUuidSync(matrixData.grid.uuid) as SR5Item<'grid'> | undefined;
         if (!grid) return;
 
         await NetworkStorage.addSlave(grid, slave);
@@ -488,7 +488,7 @@ export class MatrixNetworkFlow {
      */
     static async storeLastUsedGrid(actor: SR5Actor, network: SR5Item<'grid'>) {
         if (actor.isType('ic')) return;
-        await actor.update({system: {matrix: {grid: network.uuid}}});
+        await actor.update({system: {matrix: {grid: {uuid: network.uuid}}}});
     }
 
     /**

--- a/src/module/item/flows/MatrixNetworkFlow.ts
+++ b/src/module/item/flows/MatrixNetworkFlow.ts
@@ -218,17 +218,17 @@ export class MatrixNetworkFlow {
     static async disconnectNetwork(slave: SR5Actor | SR5Item) {
         const master = MatrixNetworkFlow.getMaster(slave);
         await NetworkStorage.removeFromNetworks(slave);
-
         await MatrixNetworkFlow._triggerUpdateForNetworkConnectionChange(master, slave);
 
         // Reconnect to previously used grid, if any.
         if (slave instanceof SR5Item || !(master instanceof SR5Item)) return;
-
         await MatrixNetworkFlow.reconnectToLastGrid(slave, master);
     }
 
     /**
      * Reconnect a matrix actor to its last used grid after disconnecting from a host.
+     * 
+     * Apply SR5#239 'Enter/Exit Host' reconnect to last grid.
      * 
      * @param slave The matrix actor to reconnect.
      * @param master The item (typically a host) the actor is being disconnected from.
@@ -243,8 +243,7 @@ export class MatrixNetworkFlow {
         if (!matrixData?.grid.uuid) return;
 
         const grid = foundry.utils.fromUuidSync(matrixData.grid.uuid) as SR5Item<'grid'> | undefined;
-        if (!grid) return;
-
+        if (!grid || !grid.isType('grid')) return;
         await NetworkStorage.addSlave(grid, slave);
     }
 

--- a/src/module/item/flows/MatrixNetworkFlow.ts
+++ b/src/module/item/flows/MatrixNetworkFlow.ts
@@ -488,6 +488,7 @@ export class MatrixNetworkFlow {
      */
     static async storeLastUsedGrid(actor: SR5Actor, network: SR5Item<'grid'>) {
         if (actor.isType('ic')) return;
+        if (!network.isType('grid')) return;
         await actor.update({system: {matrix: {grid: {uuid: network.uuid}}}});
     }
 

--- a/src/module/types/template/Matrix.ts
+++ b/src/module/types/template/Matrix.ts
@@ -2,7 +2,7 @@ import { ModifiableField } from "../fields/ModifiableField";
 import { AttributeField } from "./Attributes";
 import { ConditionData } from "./Condition";
 
-const { SchemaField, NumberField, BooleanField, AnyField, StringField, ArrayField } = foundry.data.fields;
+const { SchemaField, NumberField, BooleanField, AnyField, StringField, ArrayField, DocumentUUIDField } = foundry.data.fields;
 
 const DeviceAttribute = (initialAtt: '' | 'attack' | 'sleaze' | 'data_processing' | 'firewall', editable: boolean) => ({
     value: new NumberField({ required: true, nullable: false, integer: true, initial: 0, min: 0 }),
@@ -35,6 +35,7 @@ export const MatrixMarksTarget = () => (
     }))
 );
 
+// Intended for limited matrix actors, shared across all.
 export const MatrixData = () => ({
     attack: new ModifiableField(MatrixAttributeField()),
     sleaze: new ModifiableField(MatrixAttributeField()),
@@ -54,7 +55,8 @@ export const MatrixData = () => ({
     running_silent: new BooleanField(),
     item: new AnyField({ required: false }),
     marks: MatrixMarksTarget(),
-});
+    grid: new DocumentUUIDField()
+})
 
 export type MatrixType = foundry.data.fields.SchemaField.InitializedData<ReturnType<typeof MatrixData>>;
 export type MatrixAttributesType = foundry.data.fields.SchemaField.InitializedData<ReturnType<typeof MatrixAttributes>>;

--- a/src/module/types/template/Matrix.ts
+++ b/src/module/types/template/Matrix.ts
@@ -35,6 +35,10 @@ export const MatrixMarksTarget = () => (
     }))
 );
 
+export const LastGridData = () => ({
+    uuid: new DocumentUUIDField()
+});
+
 // Intended for limited matrix actors, shared across all.
 export const MatrixData = () => ({
     attack: new ModifiableField(MatrixAttributeField()),
@@ -55,7 +59,7 @@ export const MatrixData = () => ({
     running_silent: new BooleanField(),
     item: new AnyField({ required: false }),
     marks: MatrixMarksTarget(),
-    grid: new DocumentUUIDField()
+    grid: new SchemaField(LastGridData())
 })
 
 export type MatrixType = foundry.data.fields.SchemaField.InitializedData<ReturnType<typeof MatrixData>>;


### PR DESCRIPTION
### Approach
- store the last used grid uuid for later reconnecting or information retrieval
- It's stored on document system data as it's only needed on document. Network information is stored in global storage since it's both needed by the master and slave of each network relationship, to faciliate quick access from both sides without having to parse all world documents.

- When connecting to any grid it will be stored as last (`system.matrix.grid`)
- When disconnecting a host, try to reconnect to the last stored grid
- When disconnecting a grid, allow user to have no network connection at all
- Last used grid will not be cleared when disconnecting grid, connecting a host after and then disconnecting will auto connect to whatever last used grid

<img width="154" height="359" alt="grafik" src="https://github.com/user-attachments/assets/9e41499c-ad94-40d1-8c88-cb5ed1d3cbeb" />
<img width="428" height="446" alt="grafik" src="https://github.com/user-attachments/assets/8f091048-66c1-4489-ac16-043a756e9328" />
<img width="206" height="382" alt="grafik" src="https://github.com/user-attachments/assets/b2b13a3f-2d21-4ba2-b03f-db2d50354eea" />
<img width="162" height="352" alt="grafik" src="https://github.com/user-attachments/assets/c3a63e53-7451-4a24-a608-782de9946f80" />


### Discussions
- [x] `system.matrix.grid` could be a schemafield and contain `{uuid: string, is_public: boolean, ...}`. We might want to do it this way to have more metadata stored, if we ever wanted to. is_public is an example, removing the need to retrieve the grid for any public checks, but would also be out of sync with the actual grid info. BUT it could be used for the modifier checks n3rf is been doing.