### PR TITLE
[Bug] Use speaker name across matrix dialog and messages consistently, use speakerName helper

### DIFF
--- a/src/templates/apps/dialogs/matrix-test-dialog.hbs
+++ b/src/templates/apps/dialogs/matrix-test-dialog.hbs
@@ -32,7 +32,7 @@
             <!-- Persona targeted -->
             <div class="form-group">
                 <label>{{localize "SR5.Target"}}</label>
-                <div>{{test.persona.name}}</div>
+                <div>{{speakerName test.persona}}</div>
             </div>
             {{/if}}
             {{#if test.host}}

--- a/src/templates/chat/matrix-test-message.hbs
+++ b/src/templates/chat/matrix-test-message.hbs
@@ -11,8 +11,8 @@
             <div class="container__row">
                 <div class="container__col">
                     <div class="document">
-                        <a class="chat-select-link" data-token-id="{{test.icon.id}}"><img src="{{test.icon.img}}" class="entity-selectable"/></a>
-                         <h3 class="header-name"><a class="chat-document-link" data-uuid="{{test.icon.uuid}}">{{test.icon.name}}</a></h3>
+                        <a class="chat-select-link" data-token-id="{{test.icon.id}}"><img src="{{speakerImg test.icon}}" class="entity-selectable"/></a>
+                         <h3 class="header-name"><a class="chat-document-link" data-uuid="{{test.icon.uuid}}">{{speakerName test.icon}}</a></h3>
                     </div>
                 </div>
             </div>


### PR DESCRIPTION
Previously it would look like this:
- icon list uses token name / img
- test dialog uses actor name / img
- test message uses actor name / img

Now all three places use the token name / img. Devices (items) are handled within the speakerName helper, so both actors and icons can be combined with the speakerName helper.
