### PR TITLE
[Feature] Translate item names based on content translation

### DIFF
--- a/public/locale/de/config.json
+++ b/public/locale/de/config.json
@@ -1247,7 +1247,9 @@
             "MeleeAttackTest": "Nahkampfangriff",
             "NaturalRecoveryPhysicalTest": "Natürliche körperliche Genesung",
             "NaturalRecoveryStunTest": "Natürliche geistige Genesung",
+            "OpposedBruteForceTest": "Widerstehe Brute Force",
             "OpposedCompileSpriteTest": "Widerstehe Kompilierung",
+            "OpposedHackOnTheFlyTest": "Widerstehe Eiliges Hacken",
             "OpposedRitualTest": "Besiegel das Ritual",
             "OpposedSummonSpiritTest": "Widerstehe Herbeirufung",
             "OpposedTest": "Vergleichende Probe",
@@ -1568,7 +1570,11 @@
             "Type": "Typ",
             "Weapon": "Waffen"
         },
-        "Wireless": "WiFi"
+        "Wireless": "WiFi",
+        "Content": {
+            "Brute Force": "Brute Force",
+            "Hack on the Fly": "Eiliges Hacken"
+        }
     },
     "TYPES": {
         "Actor": {

--- a/src/module/actor/sheets/SR5MatrixActorSheet.ts
+++ b/src/module/actor/sheets/SR5MatrixActorSheet.ts
@@ -16,7 +16,7 @@ export interface MatrixActorSheetData extends SR5ActorSheetData {
     markedDocuments: Shadowrun.MarkedDocument[]
     handledItemTypes: string[]
     network: SR5Item | null
-    matrixActions: SR5Item[]
+    matrixActions: {name: string, action: SR5Item}[]
     selectedMatrixTarget: string|undefined
     // Stores icons connected to the selected matrix target.
     selectedMatrixTargetIcons: Shadowrun.MatrixTargetDocument[];
@@ -268,7 +268,7 @@ export class SR5MatrixActorSheet extends SR5BaseActorSheet {
      *
      * If a marked document is selected, only actions with a mark requirement will show.
      *
-     * @returns Alphabetically sorted array of matrix actions.
+     * @returns Sorted list of objects containg a localized name and action item for sheet display.
      */
     async _prepareMatrixActions() {
         const packActions = await this._getMatrixPackActions();
@@ -282,7 +282,14 @@ export class SR5MatrixActorSheet extends SR5BaseActorSheet {
             actions = actions.filter(action => (action.system.action.category.matrix?.marks ?? 0) <= marks);
         }
 
-        return actions.sort(Helpers.sortByName.bind(Helpers)) as SR5Item[];
+        // Prepare sorting and display of a possibly translated document name.
+        return actions.map(action => {
+                return {
+                    name: Helpers.localizeContent(action.name),
+                    action
+                };
+            })
+            .sort(Helpers.sortByName.bind(Helpers));
     }
 
     /**

--- a/src/module/handlebars/HandlebarManager.ts
+++ b/src/module/handlebars/HandlebarManager.ts
@@ -6,6 +6,7 @@ import { registerAppHelpers } from "./AppHelpers";
 import { registerBasicHelpers } from "./BasicHelpers";
 import { registerActorHelpers } from './ActorHelpers';
 import { registerModifierHelpers } from './ModifierHelpers';
+import { registerLocalizationHelpers } from './LocalizationHelpers';
 
 export class HandlebarManager {
     static async loadTemplates() {
@@ -19,5 +20,6 @@ export class HandlebarManager {
         registerAppHelpers();
         registerActorHelpers();
         registerModifierHelpers();
+        registerLocalizationHelpers();
     }
 }

--- a/src/module/handlebars/LocalizationHelpers.ts
+++ b/src/module/handlebars/LocalizationHelpers.ts
@@ -1,0 +1,19 @@
+import { Helpers } from "../helpers";
+
+/**
+ * Provide helpers for localization purposes.
+ */
+export const registerLocalizationHelpers = () => {
+    /**
+     * Localizes content based on the provided name.
+     *
+     * Intended for use when localizing content names (for example pack items) from
+     * their names to the users language.
+     * 
+     * @param name The name of the content to localize. Example 'Brute Force' 
+     * @returns Either the localized value or the original name.
+     */
+    Handlebars.registerHelper('localizeContent', (name: string) => {
+        return Helpers.localizeContent(name);
+    });
+};

--- a/src/module/helpers.ts
+++ b/src/module/helpers.ts
@@ -1165,4 +1165,18 @@ export class Helpers {
         if (a.name < b.name) return -1;
         return 0;
     }
+
+    /**
+     * Localizes a content name if a translation exists.
+     *
+     * Content tends to be the name on an item.
+     *
+     * @param name The content name to localize.
+     * @returns Sheet usable text, either translated or original name.
+     */
+    static localizeContent(name: string): string {
+        const label = `SR5.Content.${name}`;
+        const localized = game.i18n.localize(label);
+        return localized === label ? name : localized;        
+    }
 }

--- a/src/templates/actor/parts/matrix/MatrixActionList.hbs
+++ b/src/templates/actor/parts/matrix/MatrixActionList.hbs
@@ -6,11 +6,12 @@
     {{#each matrixActions}}
         {{> 'systems/shadowrun5e/dist/templates/common/List/ListItem.hbs'
             name=this.name
-            itemId=this.uuid
+            itemId=this.action.uuid
+            img=this.action.img
             itemType="matrix-action"
             hasRoll="true"
             hasDesc="true"
-            rightSide=(MatrixActionsItemRightSide this)
+            rightSide=(MatrixActionsItemRightSide this.action)
         }}
     {{/each}}
 </div>

--- a/src/templates/apps/dialogs/parts/success-test-documents.hbs
+++ b/src/templates/apps/dialogs/parts/success-test-documents.hbs
@@ -17,6 +17,6 @@
 {{#if test.item}}
 <div class="document">
     <img src="{{test.item.img}}"/>
-    <a class="content-link" data-type="Item" data-link data-id="{{test.item.id}}" data-uuid="{{test.item.uuid}}">{{test.item.name}}</a>
+    <a class="content-link" data-type="Item" data-link data-id="{{test.item.id}}" data-uuid="{{test.item.uuid}}">{{localizeContent test.item.name}}</a>
 </div>
 {{/if}}

--- a/src/templates/rolls/success-test-message.hbs
+++ b/src/templates/rolls/success-test-message.hbs
@@ -20,7 +20,7 @@
                 <div class="container__col">
                     <div class="document">
                         <img src="{{item.img}}" data-tooltip="{{item.name}}"/>
-                        <h3 class="header-name"><a class="chat-document-link" data-entity="Item" data-id="{{item.id}}" data-uuid="{{item.uuid}}">{{item.name}}</a></h3>
+                        <h3 class="header-name"><a class="chat-document-link" data-entity="Item" data-id="{{item.id}}" data-uuid="{{item.uuid}}">{{localizeContent item.name}}</a></h3>
                     </div>
                 </div>
             </div>


### PR DESCRIPTION
This proposes a solution for the custom pack name translation issue.

Issue: When a GM wants to fully replace a compendium with documents that contain content actions with a predefined name in english, they sometimes would like to have localized names.

Problem: The system can only retrieve documents from packs by uuid or name. As the packs can be changed we can't rely on the uuid (to technical). However the name itself is supposed to be changed.

This solutions makes a compromise:
- Changing of pack document names isn´t supported
- The system provides translations to content names using the "SR5.Contents" Translation list that contains all content names.

If users want translated content for their language, they must provide a i18n for it that the system can add. This we can also source actively from the community, if needed.

### Open Topics
- [ ] How should the Content name be stored in i18n json? "Brute Force" or "BruteForce"?
- [ ] Should we use technical names as item names "<brute_force>" to indicate they shouldn´t be changed?
- [ ] Should we implement features to prohibit chaning of pack name when imported into a custom pack used by the system?