### PR TITLE
[BUGFIX] Disconnect from network and cleanup MARKs upon being deleted

### DIFF
--- a/src/module/actor/SR5Actor.ts
+++ b/src/module/actor/SR5Actor.ts
@@ -2232,4 +2232,16 @@ export class SR5Actor<SubType extends Actor.ConfiguredSubType = Actor.Configured
     getExtraMarkDamageModifier() {
         return 2;
     }
+
+    /**
+     * Handle system specific things when this actor is being deleted
+     * - NOTE that this does not apply to Token Actors. Those are handled through SR5TokenDocument
+     * @param options
+     * @param user
+     */
+    override async _preDelete(options, user) {
+        // NetworkStorage needs to be cleared of us before we are deleted
+        await this.disconnectNetwork();
+        return super._preDelete(options, user);
+    }
 }

--- a/src/module/actor/SR5Actor.ts
+++ b/src/module/actor/SR5Actor.ts
@@ -2234,12 +2234,23 @@ export class SR5Actor<SubType extends Actor.ConfiguredSubType = Actor.Configured
     }
 
     /**
+     * Delete References to this actor and all owned items in the Storage areas
+     */
+    async deleteStorageReferences(this: SR5Actor) {
+        // when an actor is deleted, handle deleting all owned items
+        for (const item of this.items) {
+            await item.deleteStorageReferences();
+        }
+        await MatrixNetworkFlow.handleOnDeleteDocument(this);
+    }
+
+    /**
      * Handle system specific things when this actor is being deleted
      * - NOTE that this does not apply to Token Actors. Those are handled through SR5TokenDocument
      * @param args
      */
     override async _preDelete(...args: Parameters<Actor["_preDelete"]>) {
-        await MatrixNetworkFlow.handleOnDeleteDocument(this);
+        await this.deleteStorageReferences()
         return super._preDelete(...args);
     }
 }

--- a/src/module/actor/SR5Actor.ts
+++ b/src/module/actor/SR5Actor.ts
@@ -2236,12 +2236,11 @@ export class SR5Actor<SubType extends Actor.ConfiguredSubType = Actor.Configured
     /**
      * Handle system specific things when this actor is being deleted
      * - NOTE that this does not apply to Token Actors. Those are handled through SR5TokenDocument
-     * @param options
-     * @param user
+     * @param args
      */
-    override async _preDelete(options, user) {
+    override async _preDelete(...args: Parameters<Actor["_preDelete"]>) {
         // NetworkStorage needs to be cleared of us before we are deleted
         await this.disconnectNetwork();
-        return super._preDelete(options, user);
+        return super._preDelete(...args);
     }
 }

--- a/src/module/actor/SR5Actor.ts
+++ b/src/module/actor/SR5Actor.ts
@@ -2239,8 +2239,7 @@ export class SR5Actor<SubType extends Actor.ConfiguredSubType = Actor.Configured
      * @param args
      */
     override async _preDelete(...args: Parameters<Actor["_preDelete"]>) {
-        // NetworkStorage needs to be cleared of us before we are deleted
-        await this.disconnectNetwork();
+        await MatrixNetworkFlow.handleOnDeleteDocument(this);
         return super._preDelete(...args);
     }
 }

--- a/src/module/hooks.ts
+++ b/src/module/hooks.ts
@@ -117,7 +117,6 @@ import { Weapon } from './types/item/Weapon';
 
 import { SRStorage } from './storage/storage';
 import { MatrixICFlow } from './actor/flows/MatrixICFlow';
-import { ItemMarksFlow } from './item/flows/ItemMarksFlow';
 import { MatrixNetworkFlow } from './item/flows/MatrixNetworkFlow';
 import { SocketMessage } from './sockets';
 import { TagifyHooks } from '@/module/tagify/TagifyHooks';
@@ -153,8 +152,6 @@ export class HooksManager {
         Hooks.on('renderTokenConfig', SR5Token.tokenConfig.bind(HooksManager));
         Hooks.on('renderPrototypeTokenConfig', SR5Token.tokenConfig.bind(HooksManager));
         Hooks.on('updateItem', HooksManager.updateIcConnectedToHostItem.bind(HooksManager));
-        Hooks.on('deleteItem', HooksManager.onDeleteItem.bind(HooksManager));
-        Hooks.on('deleteActor', HooksManager.onDeleteActor.bind(HooksManager));
         Hooks.on('getChatMessageContextOptions', SuccessTest.chatMessageContextOptions.bind(SuccessTest));
 
         Hooks.on("renderChatLog", HooksManager.chatLogListeners.bind(HooksManager));
@@ -576,21 +573,6 @@ ___________________
                 await MatrixICFlow.handleUpdateItemHost(item);
                 break;
         }
-    }
-
-    /**
-     * Collect all changes necessary when any item is deleted.
-     */
-    static async onDeleteItem(item: SR5Item, data: SR5Item['system'], id: string) {
-        await MatrixNetworkFlow.handleOnDeleteDocument(item, data, id);
-        await ItemMarksFlow.handleOnDeleteItem(item, data, id);
-    }
-
-    /**
-     * Collect all changes necessary when any actor is deleted.
-     */
-    static async onDeleteActor(actor: SR5Actor, data: SR5Actor['system'], id: string) {
-        return MatrixNetworkFlow.handleOnDeleteDocument(actor, data, id);
     }
 
     /**

--- a/src/module/item/SR5Item.ts
+++ b/src/module/item/SR5Item.ts
@@ -1423,4 +1423,21 @@ export class SR5Item<SubType extends Item.ConfiguredSubType = Item.ConfiguredSub
 
         return super._preUpdate(changed, options, user);
     }
+
+    /**
+     * Handle system specific things before this item is deleted
+     * @param options
+     * @param user
+     */
+    override async _preDelete(options, user) {
+        // check if we are our owners active matrix device
+        if (this.isEquipped() && this.actorOwner?.getMatrixDevice() === this) {
+            await this.actorOwner?.disconnectNetwork();
+        }
+        // even if we weren't the actor's matrix device we may still be connected to a network
+        await this.disconnectFromNetwork();
+        // remove any matrix slaved items we have connected
+        await this.removeAllSlaves();
+        return await super._preDelete(options, user);
+    }
 }

--- a/src/module/item/SR5Item.ts
+++ b/src/module/item/SR5Item.ts
@@ -1429,14 +1429,8 @@ export class SR5Item<SubType extends Item.ConfiguredSubType = Item.ConfiguredSub
      * @param args
      */
     override async _preDelete(...args: Parameters<Item["_preDelete"]>) {
-        // check if we are our owners active matrix device
-        if (this.isEquipped() && this.actorOwner?.getMatrixDevice() === this) {
-            await this.actorOwner?.disconnectNetwork();
-        }
-        // even if we weren't the actor's matrix device we may still be connected to a network
-        await this.disconnectFromNetwork();
-        // remove any matrix slaved items we have connected
-        await this.removeAllSlaves();
+        await ItemMarksFlow.handleOnDeleteItem(this);
+        await MatrixNetworkFlow.handleOnDeleteDocument(this);
         return await super._preDelete(...args);
     }
 }

--- a/src/module/item/SR5Item.ts
+++ b/src/module/item/SR5Item.ts
@@ -1426,10 +1426,9 @@ export class SR5Item<SubType extends Item.ConfiguredSubType = Item.ConfiguredSub
 
     /**
      * Handle system specific things before this item is deleted
-     * @param options
-     * @param user
+     * @param args
      */
-    override async _preDelete(options, user) {
+    override async _preDelete(...args: Parameters<Item["_preDelete"]>) {
         // check if we are our owners active matrix device
         if (this.isEquipped() && this.actorOwner?.getMatrixDevice() === this) {
             await this.actorOwner?.disconnectNetwork();
@@ -1438,6 +1437,6 @@ export class SR5Item<SubType extends Item.ConfiguredSubType = Item.ConfiguredSub
         await this.disconnectFromNetwork();
         // remove any matrix slaved items we have connected
         await this.removeAllSlaves();
-        return await super._preDelete(options, user);
+        return await super._preDelete(...args);
     }
 }

--- a/src/module/item/SR5Item.ts
+++ b/src/module/item/SR5Item.ts
@@ -1424,13 +1424,17 @@ export class SR5Item<SubType extends Item.ConfiguredSubType = Item.ConfiguredSub
         return super._preUpdate(changed, options, user);
     }
 
+    async deleteStorageReferences(this: SR5Item) {
+        await ItemMarksFlow.handleOnDeleteItem(this);
+        await MatrixNetworkFlow.handleOnDeleteDocument(this);
+    }
+
     /**
      * Handle system specific things before this item is deleted
      * @param args
      */
     override async _preDelete(...args: Parameters<Item["_preDelete"]>) {
-        await ItemMarksFlow.handleOnDeleteItem(this);
-        await MatrixNetworkFlow.handleOnDeleteDocument(this);
+        await this.deleteStorageReferences();
         return await super._preDelete(...args);
     }
 }

--- a/src/module/item/flows/ItemMarksFlow.ts
+++ b/src/module/item/flows/ItemMarksFlow.ts
@@ -91,10 +91,8 @@ export const ItemMarksFlow = {
      *       This can result in lingering network devices or masters, when no GM or device owner is active.
      *
      * @param item This can be a network master or device or neither.
-     * @param data The item data given by FoundryVTT deleteItem event
-     * @param id The item id
      */
-    async handleOnDeleteItem(item: SR5Item, data: SR5Item['system'], id: string) {
+    async handleOnDeleteItem(item: SR5Item) {
         console.debug(`Shadowrun 5e | Checking for marks for a deleted item ${item.name}`, item);
 
         await MarksStorage.clearRelations(item.uuid);

--- a/src/module/item/flows/MatrixNetworkFlow.ts
+++ b/src/module/item/flows/MatrixNetworkFlow.ts
@@ -195,10 +195,8 @@ export class MatrixNetworkFlow {
      *       This can result in lingering network devices or masters, when no GM or device owner is active.
      *
      * @param document This can be a network master or device or neither.
-     * @param data The document data given by FoundryVTT deleteItem event
-     * @param id The document id
      */
-    static async handleOnDeleteDocument(document: SR5Actor | SR5Item, data: any, id: string) {
+    static async handleOnDeleteDocument(document: SR5Actor | SR5Item) {
         console.debug(`Shadowrun 5e | Checking for network on deleted item ${document.name}`, document);
         // A deleted master must be removed from all its devices.
         if (document instanceof SR5Item && document.canBeMaster) return MatrixNetworkFlow.removeAllSlaves(document);

--- a/src/module/storage/NetworkStorage.ts
+++ b/src/module/storage/NetworkStorage.ts
@@ -124,7 +124,17 @@ export const NetworkStorage = {
         const networks = NetworkStorage.getStorage();
         const masterUuid = Helpers.uuidForStorage(master.uuid);
         const slaveUuids = networks[masterUuid] ?? [];
-        return slaveUuids.map(uuid => fromUuidSync(Helpers.uuidFromStorage(uuid))) as (SR5Actor | SR5Item)[];
+        const slaves = [] as (SR5Actor | SR5Item)[];
+        for (const uuid of slaveUuids) {
+            const item = fromUuidSync(Helpers.uuidFromStorage(uuid));
+            // in case we have a stale id in storage, only add valid items
+            if (item) {
+                slaves.push(item as (SR5Actor | SR5Item));
+            } else {
+                console.warn(`Could not find item from id ${uuid}. Consider clearing all Networked Items for ${master?.name}`)
+            }
+        }
+        return slaves;
     },
 
     /**

--- a/src/module/storage/NetworkStorage.ts
+++ b/src/module/storage/NetworkStorage.ts
@@ -124,7 +124,7 @@ export const NetworkStorage = {
         const networks = NetworkStorage.getStorage();
         const masterUuid = Helpers.uuidForStorage(master.uuid);
         const slaveUuids = networks[masterUuid] ?? [];
-        const slaves = [] as (SR5Actor | SR5Item)[];
+        const slaves: (SR5Actor | SR5Item)[] = [];
         for (const uuid of slaveUuids) {
             const item = fromUuidSync(Helpers.uuidFromStorage(uuid));
             // in case we have a stale id in storage, only add valid items

--- a/src/module/token/SR5TokenDocument.ts
+++ b/src/module/token/SR5TokenDocument.ts
@@ -1,3 +1,5 @@
+import { MatrixNetworkFlow } from '@/module/item/flows/MatrixNetworkFlow';
+
 export class SR5TokenDocument extends TokenDocument {
     /**
      * Used by measureMovementPath to track if a movement is being planned or executed.
@@ -27,7 +29,7 @@ export class SR5TokenDocument extends TokenDocument {
     override async _preDelete(...args: Parameters<TokenDocument["_preDelete"]>) {
         // ensure we disconnect from any networks before being a token actor is deleted
         if (this.actor?.isToken) {
-            await this.actor?.disconnectNetwork();
+            await MatrixNetworkFlow.handleOnDeleteDocument(this.actor);
         }
         return super._preDelete(...args);
     }

--- a/src/module/token/SR5TokenDocument.ts
+++ b/src/module/token/SR5TokenDocument.ts
@@ -21,6 +21,17 @@ export class SR5TokenDocument extends TokenDocument {
     }
 
     /**
+     * Handle system specific things when this token document is being deleted
+     * @param options
+     * @param user
+     */
+    override async _preDelete(options, user) {
+        // ensure we disconnect from any networks before being deleted
+        await this.actor?.disconnectNetwork();
+        return super._preDelete(options, user);
+    }
+
+    /**
      * This method measures the distance a Token moves through the provided waypoints.
      * If the token actor implements MovementActorData and the selected movement action is 'walk', it will change the movement
      * action for each waypoint according to the rules for walking/running/sprinting.

--- a/src/module/token/SR5TokenDocument.ts
+++ b/src/module/token/SR5TokenDocument.ts
@@ -29,7 +29,7 @@ export class SR5TokenDocument extends TokenDocument {
     override async _preDelete(...args: Parameters<TokenDocument["_preDelete"]>) {
         // ensure we disconnect from any networks before being a token actor is deleted
         if (this.actor?.isToken) {
-            await MatrixNetworkFlow.handleOnDeleteDocument(this.actor);
+            await this.actor.deleteStorageReferences();
         }
         return super._preDelete(...args);
     }

--- a/src/module/token/SR5TokenDocument.ts
+++ b/src/module/token/SR5TokenDocument.ts
@@ -22,13 +22,12 @@ export class SR5TokenDocument extends TokenDocument {
 
     /**
      * Handle system specific things when this token document is being deleted
-     * @param options
-     * @param user
+     * @param args
      */
-    override async _preDelete(options, user) {
+    override async _preDelete(...args: Parameters<TokenDocument["_preDelete"]>) {
         // ensure we disconnect from any networks before being deleted
         await this.actor?.disconnectNetwork();
-        return super._preDelete(options, user);
+        return super._preDelete(...args);
     }
 
     /**

--- a/src/module/token/SR5TokenDocument.ts
+++ b/src/module/token/SR5TokenDocument.ts
@@ -25,8 +25,10 @@ export class SR5TokenDocument extends TokenDocument {
      * @param args
      */
     override async _preDelete(...args: Parameters<TokenDocument["_preDelete"]>) {
-        // ensure we disconnect from any networks before being deleted
-        await this.actor?.disconnectNetwork();
+        // ensure we disconnect from any networks before being a token actor is deleted
+        if (this.actor?.isToken) {
+            await this.actor?.disconnectNetwork();
+        }
         return super._preDelete(...args);
     }
 


### PR DESCRIPTION
This handles token and sidebar actors to disconnect from networks. Items will also remove all slaved items.

I noticed that the Actor _preDelete was not being called when a token actor was deleted. Luckily that appears to be what SR5TokenDocument is being used for so I implemented it there as well.