### PR TITLE
[Feature] Add a few links to navigate Networked Items

### DIFF
--- a/src/module/actor/sheets/SR5MatrixActorSheet.ts
+++ b/src/module/actor/sheets/SR5MatrixActorSheet.ts
@@ -21,7 +21,9 @@ export interface MatrixActorSheetData extends SR5ActorSheetData {
     // Stores icons connected to the selected matrix target.
     selectedMatrixTargetIcons: Shadowrun.MatrixTargetDocument[];
     // Targets to be displayed in the matrix tab.
-    matrixTargets: Shadowrun.MatrixTargetDocument[]
+    matrixTargets: Shadowrun.MatrixTargetDocument[];
+    // the master device being used to connect to the matrix
+    matrixDevice: SR5Item | undefined;
 }
 
 export class SR5MatrixActorSheet extends SR5BaseActorSheet {
@@ -50,8 +52,17 @@ export class SR5MatrixActorSheet extends SR5BaseActorSheet {
 
         this._prepareMatrixTargets(data);
         await this._prepareMarkedDocuments(data);
+        this._prepareMatrixDevice(data);
 
         return data;
+    }
+
+    /**
+     * Add the currently equipped matrix device to the sheet data
+     * @param data
+     */
+    _prepareMatrixDevice(data: MatrixActorSheetData) {
+        data.matrixDevice = this.actor?.getMatrixDevice();
     }
 
     _prepareMatrixTargets(data: MatrixActorSheetData) {

--- a/src/module/item/SR5ItemSheet.ts
+++ b/src/module/item/SR5ItemSheet.ts
@@ -415,6 +415,7 @@ export class SR5ItemSheet extends foundry.appv1.sheets.ItemSheet {
         html.find('input[name="system.technology.equipped"').on('change', this._onToggleEquippedDisableOtherDevices.bind(this))
 
         html.find('.list-item').each(this._addDragSupportToListItemTemplatePartial.bind(this));
+        html.find('.open-matrix-slave').on('click', this._onOpenSlave.bind(this));
 
         html.find('.power-optional-input').on('change', this._onPowerOptionalInputChanged.bind(this));
 
@@ -758,6 +759,26 @@ export class SR5ItemSheet extends foundry.appv1.sheets.ItemSheet {
         if (!document) return;
 
         await this.item.removeSlave(document);
+    }
+
+    /**
+     * Open a document from a DOM node containing a dataset uuid.
+     *
+     * This is intended to let deckers open marked documents they're FoundryVTT user has permissions for.
+     *
+     * @param event Any interaction event
+     */
+    async _onOpenSlave(event) {
+        event.stopPropagation();
+
+        const uuid = Helpers.listItemUuid(event);
+        if (!uuid) return;
+
+        // Marked documents can´t live in packs.
+        const document = fromUuidSync(uuid) as SR5Item|SR5Actor;
+        if (!document) return;
+
+        await document.sheet?.render(true);
     }
 
     /**

--- a/src/templates/actor/tabs/MatrixTab.hbs
+++ b/src/templates/actor/tabs/MatrixTab.hbs
@@ -1,5 +1,12 @@
 {{#> 'systems/shadowrun5e/dist/templates/common/TabWrapper.hbs' tabId='matrix'}}
 <div class="flexrow list-header item-section space-between">
+    {{#if matrixDevice}}
+    <div>
+        <a class="open-matrix-device roll" data-uuid="{{matrixDevice.uuid}}">
+            {{matrixDevice.name}}
+        </a>
+    </div>
+    {{/if}}
     <div class="RollId" data-roll-id="matrix.device-rating">
         <a class="roll Roll">
             {{localize "SR5.Labels.ActorSheet.DeviceRating"}}: {{system.matrix.rating}}
@@ -37,7 +44,7 @@
             <div class="flexrow align-start list-header item-section space-between">
                 <div>
                     {{#if network}}
-                    {{localize "SR5.Labels.ActorSheet.Network"}}: {{network.name}}
+                    {{localize "SR5.Labels.ActorSheet.Network"}}: <a class="open-matrix-device" data-uuid="{{network.uuid}}">{{network.name}}</a>
                     <a data-tooltip="SR5.Tooltips.Actor.DisconnectNetwork">
                         <i class="item-icon fas fa-right-from-bracket disconnect-network"></i>
                     </a>

--- a/src/templates/actor/tabs/NetworkTab.hbs
+++ b/src/templates/actor/tabs/NetworkTab.hbs
@@ -13,12 +13,12 @@
             <div class="list-item-content">
                 <div class="item-left">
                     <div class="item-img">
-                        <img src="{{this.img}}"
-                            data-tooltip="{{this.name}}"
+                        <img src="{{speakerImg this}}"
+                            data-tooltip="{{speakerName this}}"
                             height="24px"
                             width="24px"/>
                     </div>
-                    <div class="item-text item-name">{{this.name}}</div>
+                    <div class="item-text item-name open-matrix-slave roll">{{speakerName this}}</div>
                 </div>
                 <div class="item-right">
                     <div class="item-text">


### PR DESCRIPTION
This adds a links on the actor and item sheets to allow opening the items in the PAN or WAN lists, as long as they have access.
<img width="514" height="380" alt="Screenshot 2025-08-31 163825" src="https://github.com/user-attachments/assets/3f8c9b48-62a2-43e2-91a1-750d75ef8e70" />
<img width="513" height="419" alt="Screenshot 2025-08-31 163851" src="https://github.com/user-attachments/assets/f8b5a7d1-cb94-4594-b6f6-ce7cef0993d4" />
<img width="741" height="497" alt="Screenshot 2025-08-31 163907" src="https://github.com/user-attachments/assets/f1b2b74c-5315-4f76-96bf-66b9b6e9915a" />
