### PR TITLE
[Feature] Update Vehicle Matrix Tab

### DIFF
--- a/public/locale/en/config.json
+++ b/public/locale/en/config.json
@@ -709,6 +709,7 @@
                 "CreateInventory": "Create inventory place",
                 "CritterPowers": "Critter Powers",
                 "ColdSim": "Cold Sim",
+                "ConnectToDriver": "Connect To Driver",
                 "DisplayingPersona": "Displaying Persona",
                 "DeviceRating": "Device Rating",
                 "DeviceSetup": "Device Setup",

--- a/src/module/actor/sheets/SR5MatrixActorSheet.ts
+++ b/src/module/actor/sheets/SR5MatrixActorSheet.ts
@@ -6,8 +6,6 @@ import { SR5Actor } from '../SR5Actor';
 import { MatrixSheetFlow } from '../../flows/MatrixSheetFlow';
 import { ActorMarksFlow } from '../flows/ActorMarksFlow';
 import SR5ActorSheetData = Shadowrun.SR5ActorSheetData;
-import { SelectMatrixNetworkDialog } from '@/module/apps/dialogs/SelectMatrixNetworkDialog';
-import { FormDialog, FormDialogOptions } from '@/module/apps/dialogs/FormDialog';
 import { MatrixTargetingFlow } from '@/module/flows/MatrixTargetingFlow';
 import { MatrixNetworkFlow } from '@/module/item/flows/MatrixNetworkFlow';
 
@@ -97,11 +95,11 @@ export class SR5MatrixActorSheet extends SR5BaseActorSheet {
         html.find('.targets-refresh').on('click', this._onTargetsRefresh.bind(this));
 
         html.find('.setup-pan').on('click', this._addAllEquippedWirelessDevicesToPAN.bind(this));
+        // Matrix Target - Connected Icons Visibility Switch
+        html.find('.toggle-connected-matrix-icons').on('click', this._onToggleConnectedMatrixIcons.bind(this));
 
         // Matrix Network
         html.find('.connect-to-network').on('click', this._onConnectToMatrixNetwork.bind(this));
-        // Matrix Target - Connected Icons Visibility Switch
-        html.find('.toggle-connected-matrix-icons').on('click', this._onToggleConnectedMatrixIcons.bind(this));
 
         html.find('.reboot-persona-device').on('click', this._onRebootPersonaDevice.bind(this));
         html.find('.matrix-toggle-running-silent').on('click', this._onMatrixToggleRunningSilent.bind(this));
@@ -115,34 +113,7 @@ export class SR5MatrixActorSheet extends SR5BaseActorSheet {
     private async _onMatrixToggleRunningSilent(event) {
         event.preventDefault();
         event.stopPropagation();
-
-        if (!this.actor.isMatrixActor) return;
-
-        const matrixData = this.actor.matrixData();
-        if (!matrixData) return;
-
-        if (matrixData.device) {
-            const device = matrixData.device;
-            const item = this.actor.items.get(device);
-            if (!item) return;
-
-            // toggle between online and silent based on running silent status
-            const newState = item.isRunningSilent() ? 'online' : 'silent';
-
-            // update the embedded item with the new wireless state
-            await this.actor.updateEmbeddedDocuments('Item', [{
-                '_id': device,
-                system: { technology: { wireless: newState } }
-            }]);
-        } else {
-            await this.actor.update({
-                system: {
-                    matrix: {
-                        running_silent: !matrixData.running_silent,
-                    }
-                }
-            })
-        }
+        await MatrixSheetFlow.toggleRunningSilent(this.actor);
     }
 
     /**
@@ -150,43 +121,21 @@ export class SR5MatrixActorSheet extends SR5BaseActorSheet {
      * @param event Any pointer event
      */
     async _onRebootPersonaDevice(event: Event) {
-        const data = {
-            title: game.i18n.localize("SR5.RebootConfirmationDialog.Title"),
-            buttons: {
-                confirm: {
-                    label: game.i18n.localize('SR5.RebootConfirmationDialog.Confirm')
-                },
-                cancel: {
-                    label: game.i18n.localize('SR5.RebootConfirmationDialog.Cancel')
-                }
-            },
-            content: '',
-            default: 'cancel',
-            templateData: {},
-            templatePath: 'systems/shadowrun5e/dist/templates/apps/dialogs/reboot-confirmation-dialog.hbs'
-        }
-        const options = {
-            classes: ['sr5', 'form-dialog'],
-        } as FormDialogOptions;
-        const dialog = new FormDialog(data, options);
-        await dialog.select();
-        if (dialog.canceled || dialog.selectedButton !== 'confirm') return;
-
-        await this.actor.rebootPersona();
+        event.preventDefault();
+        event.stopPropagation();
+        await MatrixSheetFlow.promptRebootPersonaDevice(this.actor);
     }
 
     /**
      * Allow the user to select a matrix network to connect to.
      */
     async _onConnectToMatrixNetwork(event) {
+        event.preventDefault();
         event.stopPropagation();
 
-        const dialog = new SelectMatrixNetworkDialog(this.document);
-        const network = await dialog.select();
-        if (dialog.canceled) return;
-
-        await this.document.connectNetwork(network);
-        this.render();
+        if (await MatrixSheetFlow.promptConnectToMatrixNetwork(this.actor)) {
+            this.render();
+        }
     }
 
     /**

--- a/src/module/actor/sheets/SR5VehicleActorSheet.ts
+++ b/src/module/actor/sheets/SR5VehicleActorSheet.ts
@@ -96,10 +96,14 @@ export class SR5VehicleActorSheet extends SR5MatrixActorSheet {
 
         const dropData = JSON.parse(event.dataTransfer.getData('text/plain'));
 
-        // Handle specific system drop events.
-        switch (dropData.type) {
-            case "Actor":
-                return this.actor.addVehicleDriver(dropData.uuid)
+        if (dropData.type === 'Actor') {
+            return this.actor.addVehicleDriver(dropData.uuid)
+        } else if (dropData.type === 'Item') {
+            // if an item is dropped on us that can be a Master, connect to it
+            const item = await fromUuid(dropData.uuid) as SR5Item | undefined;
+            if (item && item.canBeMaster) {
+                return await this.actor.connectNetwork(item);
+            }
         }
 
         // Handle none specific drop events.
@@ -140,6 +144,7 @@ export class SR5VehicleActorSheet extends SR5MatrixActorSheet {
     async _handleRemoveVehicleDriver(event) {
         event.preventDefault();
         await this.actor.removeVehicleDriver();
+        this.render();
     }
 
     async _onOpenOriginLink(event) {
@@ -158,6 +163,7 @@ export class SR5VehicleActorSheet extends SR5MatrixActorSheet {
     async _onControllerRemove(event) {
         event.preventDefault();
 
-        return MatrixNetworkFlow.removeSlaveFromMaster(this.actor);
+        await MatrixNetworkFlow.removeSlaveFromMaster(this.actor);
+        this.render();
     }
 }

--- a/src/module/flows/MatrixSheetFlow.ts
+++ b/src/module/flows/MatrixSheetFlow.ts
@@ -1,5 +1,7 @@
 import { SR5Actor } from '../actor/SR5Actor';
 import { SR5Item } from '../item/SR5Item';
+import { FormDialog, FormDialogOptions } from '@/module/apps/dialogs/FormDialog';
+import { SelectMatrixNetworkDialog } from '@/module/apps/dialogs/SelectMatrixNetworkDialog';
 
 /**
  * Handling of sheet presentation around matrix data.
@@ -17,4 +19,81 @@ export const MatrixSheetFlow = {
         }
         return actions.filter((action: SR5Item) => action.hasActionCategory('matrix'));
     },
+
+    /**
+     * Handle the user request to reboot their main active matrix device or living persona.
+     * @param actor
+     */
+    async promptRebootPersonaDevice(actor: SR5Actor) {
+        const data = {
+            title: game.i18n.localize("SR5.RebootConfirmationDialog.Title"),
+            buttons: {
+                confirm: {
+                    label: game.i18n.localize('SR5.RebootConfirmationDialog.Confirm')
+                },
+                cancel: {
+                    label: game.i18n.localize('SR5.RebootConfirmationDialog.Cancel')
+                }
+            },
+            content: '',
+            default: 'cancel',
+            templateData: {},
+            templatePath: 'systems/shadowrun5e/dist/templates/apps/dialogs/reboot-confirmation-dialog.hbs'
+        }
+        const options = {
+            classes: ['sr5', 'form-dialog'],
+        } as FormDialogOptions;
+        const dialog = new FormDialog(data, options);
+        await dialog.select();
+        if (dialog.canceled || dialog.selectedButton !== 'confirm') return;
+
+        await actor.rebootPersona();
+    },
+
+    /**
+     * Handle changing if an Actor is Running Silent
+     * @param actor
+     */
+    async toggleRunningSilent(actor: SR5Actor) {
+        if (!actor.isMatrixActor) return;
+
+        const matrixData = actor.matrixData();
+        if (!matrixData) return;
+
+        if (matrixData.device) {
+            const device = matrixData.device;
+            const item = actor.items.get(device);
+            if (!item) return;
+
+            // toggle between online and silent based on running silent status
+            const newState = item.isRunningSilent() ? 'online' : 'silent';
+
+            // update the embedded item with the new wireless state
+            await actor.updateEmbeddedDocuments('Item', [{
+                '_id': device,
+                system: { technology: { wireless: newState } }
+            }]);
+        } else {
+            await actor.update({
+                system: {
+                    matrix: {
+                        running_silent: !matrixData.running_silent,
+                    }
+                }
+            })
+        }
+    },
+
+    /**
+     * Allow the user to select a matrix network to connect to.
+     * @param actor
+     */
+    async promptConnectToMatrixNetwork(actor: SR5Actor): Promise<boolean> {
+        const dialog = new SelectMatrixNetworkDialog(actor);
+        const network = await dialog.select();
+        if (dialog.canceled) return false;
+
+        await actor.connectNetwork(network);
+        return true;
+    }
 }

--- a/src/templates/actor/tabs/vehicle/VehicleMatrixTab.hbs
+++ b/src/templates/actor/tabs/vehicle/VehicleMatrixTab.hbs
@@ -1,45 +1,85 @@
 {{#> 'systems/shadowrun5e/dist/templates/common/TabWrapper.hbs' tabId='matrix'}}
-    <div>
-        {{> "systems/shadowrun5e/dist/templates/common/HeaderBlock.hbs"
-                name=(localize "SR5.Labels.ActorSheet.Matrix")
-        }}
-        <div class="attributes">
-            {{> "systems/shadowrun5e/dist/templates/actor/parts/matrix/DeviceRating.hbs" }}
-            <div class="block">
-                <div class="block-line gap-4 border-bottom center">
-                    <label>
-                        {{localize "SR5.RunningSilent"}}
-                        <input
-                                type="checkbox"
-                                class="submit-checkbox"
-                                name="system.matrix.running_silent"
-                            {{checked system.matrix.running_silent}}
-                        />
-                    </label>
-                </div>
-                <div class="attribute">
-                    <div class="attribute-name">
-                        {{localize "SR5.ConditionMonitor"}}
-                    </div>
-                    {{> 'systems/shadowrun5e/dist/templates/common/HorizontalCellInput.hbs'
-                            value=system.matrix.condition_monitor.value
-                            max=system.matrix.condition_monitor.max
-                            id="matrix"
-                    }}
-                </div>
-            </div>
-            {{#each config.matrixAttributes as |label key|}}
-                {{> "systems/shadowrun5e/dist/templates/actor/parts/matrix/MatrixAttribute.hbs"
+    <div class="flexrow list-header item-section space-between">
+        <div class="RollId" data-roll-id="matrix.device-rating">
+            <a class="roll Roll">
+                {{localize "SR5.Labels.ActorSheet.DeviceRating"}}: {{system.matrix.rating}}
+            </a>
+        </div>
+        <div>
+            <a class="matrix-toggle-running-silent" data-tooltip="SR5.Tooltips.Actor.MatrixRunningSilentToggle">
+                {{#if system.matrix.running_silent}}
+                    {{localize "SR5.RunningSilent"}}
+                {{else}}
+                    {{localize "SR5.Labels.ActorSheet.DisplayingPersona"}}
+                {{/if}}
+            </a>
+        </div>
+        <div>
+            <a class="reboot-persona-device" data-tooltip="SR5.Tooltips.Actor.RebootPersonaAndClearAllMarks">
+                {{localize "SR5.Labels.Sheet.RebootDevice"}} <i class="item-icon fas fa-power-off"></i>
+            </a>
+        </div>
+    </div>
+    <div class="split-container">
+        <div>
+            <div class="attributes">
+                {{#each config.matrixAttributes as |label key|}}
+                    {{> "systems/shadowrun5e/dist/templates/actor/parts/matrix/MatrixAttribute.hbs"
                         matrixAtt=(lookup ../system.matrix key)
                         isCyberdeck=../system.matrix.is_cyberdeck
                         key=key
                         label=label
                         matrixAttributes=../config/matrixAttributes
                         item=../system.matrix.item }}
-            {{/each}}
+                {{/each}}
+            </div>
+            <div class="inventory">
+                <div class="flexrow align-start list-header item-section space-between">
+                    <div>
+                        {{#if network}}
+                            {{localize "SR5.Labels.ActorSheet.Network"}}: <a class="open-matrix-device" data-uuid="{{network.uuid}}">{{network.name}}</a>
+                            <a data-tooltip="SR5.Tooltips.Actor.DisconnectNetwork">
+                                <i class="item-icon fas fa-right-from-bracket disconnect-network"></i>
+                            </a>
+                        {{else}}
+                            {{localize "SR5.Labels.ActorSheet.NoNetwork"}}
+                            <a class="connect-to-network">{{localize "SR5.Labels.ActorSheet.AddNetwork"}}</a>
+                        {{/if}}
+                    </div>
+                    {{#unless network}}
+                    {{#if vehicle.driver}}
+                    <div>
+                        <a class="connect-to-driver">
+                            {{localize "SR5.Labels.ActorSheet.ConnectToDriver"}} <i class="item-icon fas fa-network-wired"></i>
+                        </a>
+                    </div>
+                    {{/if}}
+                    {{/unless}}
+                </div>
+                <div>
+                    <nav class="tabs" data-group="matrix">
+                        <a class="item" data-tab="programs">{{localize "SR5.Programs"}}</a>
+                        <a class="item" data-tab="targets">{{localize "SR5.Labels.ActorSheet.Icons"}}</a>
+                    </nav>
+                    <div class="scroll-area scroll-area-matrix-hacking">
+                        <section data-group='matrix' class="tabsbody">
+                            {{> 'systems/shadowrun5e/dist/templates/actor/tabs/matrix/TargetsTab.hbs'}}
+                            {{> 'systems/shadowrun5e/dist/templates/actor/tabs/matrix/ProgramListTab.hbs'}}
+                        </section>
+                    </div>
+                </div>
+            </div>
         </div>
-    </div>
-    <div class="inventory">
-        {{> 'systems/shadowrun5e/dist/templates/actor/parts/matrix/ProgramList.hbs' }}
+        <div>
+            {{#ifgt system.matrix.condition_monitor.max 0}}
+                {{> 'systems/shadowrun5e/dist/templates/common/HorizontalCellInput.hbs'
+                    name=(localize "SR5.ConditionMonitor")
+                    value=system.matrix.condition_monitor.value
+                    max=system.matrix.condition_monitor.max
+                    id="matrix"
+                }}
+            {{/ifgt}}
+            {{> 'systems/shadowrun5e/dist/templates/actor/parts/matrix/MatrixActionList.hbs' }}
+        </div>
     </div>
 {{/ 'systems/shadowrun5e/dist/templates/common/TabWrapper.hbs'}}


### PR DESCRIPTION
This updates the Vehicle Matrix Tab to be similar to the other sheets. It has a button to connect to the driver's PAN and allows dropping master-capable devices onto the sheet. The list of matrix actions is filtered by non-illegal actions.
<img width="863" height="701" alt="image" src="https://github.com/user-attachments/assets/95e00522-13ec-48f0-879b-a62d3a1b6c6d" />
