### PR TITLE
[Bugfix] Clean up deletion of actors and fix token actor marking

### DIFF
--- a/public/locale/en/config.json
+++ b/public/locale/en/config.json
@@ -971,6 +971,13 @@
         "NormalSkillButton": "Normal",
         "NormalSpellButton": "Normal",
         "NotExtended": "Not Extended",
+        "Notifications": {
+            "DeletingStorageReferences": {
+                "Start": "Deleting Network and MARK references",
+                "Item": "Clearing references to item",
+                "Finished": "Finished clearing references"
+            }
+        },
         "Notoriety": "Notoriety",
         "Nuyen": "Nuyen",
         "OpenOrigin": "Open item",

--- a/public/locale/en/config.json
+++ b/public/locale/en/config.json
@@ -180,13 +180,6 @@
         },
         "Add": "Add",
         "AddAmmo": "Add Ammo",
-        "AddDevicesToPAN": {
-            "Adding": "Adding",
-            "Starting": "Starting to add equipped devices to PAN",
-            "FinishedAddingItems": "Finished adding devices to PAN",
-            "SetupPAN": "Add Devices to PAN",
-            "SetupPANTooltip": "Add all Equipped Wireless Devices to this character's Persona"
-        },
         "AddFifteenMinutesToOverwatch": "Roll 2d6 for 15 minutes in the matrix",
         "AddFiveToOverwatch": "+5 to OS",
         "AddMod": "Add Mod",
@@ -735,6 +728,7 @@
                 "RollDronePerception": "Drone Perception",
                 "RollPilotVehicleTest": "Pilot Vehicle",
                 "SetMonitor": "Monitor must be set manually.",
+                "SetupPAN": "Add Devices to PAN",
                 "Spells": "Spells",
                 "SpiritConfiguration": "Spirit Configuration",
                 "SpriteConfiguration": "Sprite Configuration",
@@ -976,6 +970,11 @@
                 "Start": "Deleting Network and MARK references",
                 "Item": "Clearing references to item",
                 "Finished": "Finished clearing references"
+            },
+            "AddDevicesToPAN": {
+                "Adding": "Adding",
+                "Starting": "Starting to add equipped devices to PAN",
+                "FinishedAddingItems": "Finished adding devices to PAN. Please close and reopen any item sheets that changed connections."
             }
         },
         "Notoriety": "Notoriety",
@@ -1455,7 +1454,8 @@
                 "ResetActorForNewRun": "Reset damage, edge, etc. for a new run",
                 "MatrixConnectionToggle": "Change Matrix Connection status: Augmented Reality, Cold Sim, or Hot Sim",
                 "MatrixRunningSilentToggle": "Change your matrix device between Running Silent and Displaying your Persona",
-                "RebootPersonaAndClearAllMarks": "Reboot your Persona and clear all Marks you have placed"
+                "RebootPersonaAndClearAllMarks": "Reboot your Persona and clear all Marks you have placed",
+                "SetupPAN": "Add all Equipped Wireless Devices to this character's Persona"
             },
             "Actor.DefaultCategoryVisibility": "Show item categories even if no item has been added to them",
             "CallInAction": {

--- a/src/module/actor/SR5Actor.ts
+++ b/src/module/actor/SR5Actor.ts
@@ -2257,9 +2257,9 @@ export class SR5Actor<SubType extends Actor.ConfiguredSubType = Actor.Configured
     async deleteStorageReferences(this: SR5Actor) {
         // If the actor being deleted has a lot of items, this can take some time
         // display a progress bar of the items being "deleted" so the user knows something is happening at least
-        const progressBar = ui.notifications.info(`${this.name} - ${game.i18n.localize("SR5.Notifications.DeletingStorageReferences.Starting")}`, { progress: true });
+        const progressBar = ui.notifications.info(`${this.name} - ${game.i18n.localize("SR5.Notifications.DeletingStorageReferences.Start")}`, { progress: true });
 
-        // if we have a matrix device, delete it's storage references first, this speeds up deleting their PAN
+        // if we have a matrix device, delete its storage references first, this speeds up deleting their PAN
         await this.getMatrixDevice()?.deleteStorageReferences()
         // when an actor is deleted, handle deleting all owned items
         let i = 0;
@@ -2267,7 +2267,7 @@ export class SR5Actor<SubType extends Actor.ConfiguredSubType = Actor.Configured
         for (const item of this.items) {
             progressBar.update({
                 pct: i / total,
-                message: `(${i+1}/${total}) ${this.name} - ${game.i18n.localize(`SR5.Notifications.DeletingStorageReferences.Item`)} ${item.name} `
+                message: `(${i+1}/${total}) ${this.name} - ${game.i18n.localize(`SR5.Notifications.DeletingStorageReferences.Item`)} ${item.name}`
             })
             await item.deleteStorageReferences();
             i++;
@@ -2275,7 +2275,7 @@ export class SR5Actor<SubType extends Actor.ConfiguredSubType = Actor.Configured
         // display the progress bar at 100% while we finis cleaning up the actor
         progressBar.update({
             pct: 100,
-            message: game.i18n.localize(`SR5.Notifications.DeletingStorageReferences.Finished`),
+            message: `${this.name} - ${game.i18n.localize(`SR5.Notifications.DeletingStorageReferences.Finished`)}`,
         });
         await MatrixNetworkFlow.handleOnDeleteDocument(this);
         // remove the progress bar now, we don't need to keep it around

--- a/src/module/actor/SR5Actor.ts
+++ b/src/module/actor/SR5Actor.ts
@@ -2263,12 +2263,12 @@ export class SR5Actor<SubType extends Actor.ConfiguredSubType = Actor.Configured
         let i = 0;
         const total = this.items.size;
         for (const item of this.items) {
-            i++;
             progressBar.update({
                 pct: i / total,
-                message: `(${i}/${total}) ${game.i18n.localize(`SR5.Notifications.DeletingStorageReferences.Item`)} ${item.name} `
+                message: `(${i+1}/${total}) ${game.i18n.localize(`SR5.Notifications.DeletingStorageReferences.Item`)} ${item.name} `
             })
             await item.deleteStorageReferences();
+            i++;
         }
         await MatrixNetworkFlow.handleOnDeleteDocument(this);
         progressBar.remove();

--- a/src/module/actor/SR5Actor.ts
+++ b/src/module/actor/SR5Actor.ts
@@ -2256,7 +2256,9 @@ export class SR5Actor<SubType extends Actor.ConfiguredSubType = Actor.Configured
      */
     async deleteStorageReferences(this: SR5Actor) {
         // If the actor being deleted has a lot of items, this can take some time
+        // display a progress bar of the items being "deleted" so the user knows something is happening at least
         const progressBar = ui.notifications.info(`${this.name} - ${game.i18n.localize("SR5.Notifications.DeletingStorageReferences.Starting")}`, { progress: true });
+
         // if we have a matrix device, delete it's storage references first, this speeds up deleting their PAN
         await this.getMatrixDevice()?.deleteStorageReferences()
         // when an actor is deleted, handle deleting all owned items
@@ -2265,14 +2267,19 @@ export class SR5Actor<SubType extends Actor.ConfiguredSubType = Actor.Configured
         for (const item of this.items) {
             progressBar.update({
                 pct: i / total,
-                message: `(${i+1}/${total}) ${game.i18n.localize(`SR5.Notifications.DeletingStorageReferences.Item`)} ${item.name} `
+                message: `(${i+1}/${total}) ${this.name} - ${game.i18n.localize(`SR5.Notifications.DeletingStorageReferences.Item`)} ${item.name} `
             })
             await item.deleteStorageReferences();
             i++;
         }
+        // display the progress bar at 100% while we finis cleaning up the actor
+        progressBar.update({
+            pct: 100,
+            message: game.i18n.localize(`SR5.Notifications.DeletingStorageReferences.Finished`),
+        });
         await MatrixNetworkFlow.handleOnDeleteDocument(this);
+        // remove the progress bar now, we don't need to keep it around
         progressBar.remove();
-        ui.notifications.info(game.i18n.localize(`SR5.Notifications.DeletingStorageReferences.Finished`));
     }
 
     /**

--- a/src/module/actor/sheets/SR5MatrixActorSheet.ts
+++ b/src/module/actor/sheets/SR5MatrixActorSheet.ts
@@ -180,7 +180,7 @@ export class SR5MatrixActorSheet extends SR5BaseActorSheet {
         const matrixDevice = this.actor.getMatrixDevice();
         if (matrixDevice) {
             console.debug('Shadowrun5e | Adding all equipped wireless devices to actor PAN ->', event);
-            const progressBar = ui.notifications.info(game.i18n.localize("SR5.AddDevicesToPAN.Starting"), { progress: true });
+            const progressBar = ui.notifications.info(game.i18n.localize("SR5.Notifications.AddDevicesToPAN.Starting"), { progress: true });
             const allItems = this.actor.items;
             const filteredItems: SR5Item[] = [];
             for (const item of allItems) {
@@ -192,14 +192,15 @@ export class SR5MatrixActorSheet extends SR5BaseActorSheet {
             const total = filteredItems.length;
             for (const item of filteredItems) {
                 i++;
-                await matrixDevice.addSlave(item);
+                await matrixDevice.addSlave(item, { triggerUpdate: false });
                 progressBar.update({
                     pct: i / total,
-                    message: `(${i}/${total}) ${game.i18n.localize(`SR5.AddDevicesToPAN.Adding`)} ${item.name} `
-                })
+                    message: `(${i}/${total}) ${game.i18n.localize(`SR5.Notifications.AddDevicesToPAN.Adding`)} ${item.name} `
+                });
             }
+            await MatrixNetworkFlow._triggerUpdateForNetworkConnectionChange(matrixDevice, null);
             progressBar.remove();
-            ui.notifications.info(game.i18n.localize(`SR5.AddDevicesToPAN.FinishedAddingItems`));
+            ui.notifications.info(game.i18n.localize(`SR5.Notifications.AddDevicesToPAN.FinishedAddingItems`));
         }
     }
 

--- a/src/module/flows/StorageFlow.ts
+++ b/src/module/flows/StorageFlow.ts
@@ -10,18 +10,26 @@ import { ItemMarksFlow } from '@/module/item/flows/ItemMarksFlow';
 export const StorageFlow = {
 
     /**
-     * Delete References to actor actor and all owned items in the Storage areas
+     * Delete References to an actor or item in the Global Storage areas
      */
     async deleteStorageReferences(document: SR5Actor | SR5Item | null | undefined) {
         if (document instanceof SR5Actor) return this._deleteStorageReferencesActor(document);
         else if (document instanceof SR5Item) return this._deleteStorageReferencesItem(document);
     },
 
+    /**
+     * Delete references to items in storage
+     * @param item
+     */
     async _deleteStorageReferencesItem(item: SR5Item) {
         await ItemMarksFlow.handleOnDeleteItem(item);
         await MatrixNetworkFlow.handleOnDeleteDocument(item);
     },
 
+    /**
+     * Delete references to an actor and all their owned items
+     * @param actor
+     */
     async _deleteStorageReferencesActor(actor: SR5Actor) {
         // If the actor being deleted has a lot of items, actor can take some time
         // display a progress bar of the items being "deleted" so the user knows something is happening at least
@@ -45,6 +53,7 @@ export const StorageFlow = {
             pct: 1,
             message: `${actor.name} - ${game.i18n.localize(`SR5.Notifications.DeletingStorageReferences.Finished`)}`,
         });
+        // handle our own actual deletion
         await MatrixNetworkFlow.handleOnDeleteDocument(actor);
         // remove the progress bar now, we don't need to keep it around
         progressBar.remove();

--- a/src/module/flows/StorageFlow.ts
+++ b/src/module/flows/StorageFlow.ts
@@ -1,0 +1,52 @@
+import { MatrixNetworkFlow } from '@/module/item/flows/MatrixNetworkFlow';
+import { SR5Actor } from '@/module/actor/SR5Actor';
+import { SR5Item } from '@/module/item/SR5Item';
+import { ItemMarksFlow } from '@/module/item/flows/ItemMarksFlow';
+
+/**
+ * Storage Flow Handles global storage changes when an actor or item is deleted
+ * - this should be expanded as we introduce more global storage
+ */
+export const StorageFlow = {
+
+    /**
+     * Delete References to actor actor and all owned items in the Storage areas
+     */
+    async deleteStorageReferences(document: SR5Actor | SR5Item | null | undefined) {
+        if (document instanceof SR5Actor) return this._deleteStorageReferencesActor(document);
+        else if (document instanceof SR5Item) return this._deleteStorageReferencesItem(document);
+    },
+
+    async _deleteStorageReferencesItem(item: SR5Item) {
+        await ItemMarksFlow.handleOnDeleteItem(item);
+        await MatrixNetworkFlow.handleOnDeleteDocument(item);
+    },
+
+    async _deleteStorageReferencesActor(actor: SR5Actor) {
+        // If the actor being deleted has a lot of items, actor can take some time
+        // display a progress bar of the items being "deleted" so the user knows something is happening at least
+        const progressBar = ui.notifications.info(`${actor.name} - ${game.i18n.localize("SR5.Notifications.DeletingStorageReferences.Start")}`, { progress: true });
+
+        // if we have a matrix device, delete its storage references first, actor speeds up deleting their PAN
+        await this.deleteStorageReferences(actor.getMatrixDevice());
+        // when an actor is deleted, handle deleting all owned items
+        let i = 0;
+        const total = actor.items.size;
+        for (const item of actor.items) {
+            progressBar.update({
+                pct: i / total,
+                message: `(${i+1}/${total}) ${actor.name} - ${game.i18n.localize(`SR5.Notifications.DeletingStorageReferences.Item`)} ${item.name}`
+            })
+            await this.deleteStorageReferences(item);
+            i++;
+        }
+        // display the progress bar at 100% while we finis cleaning up the actor
+        progressBar.update({
+            pct: 1,
+            message: `${actor.name} - ${game.i18n.localize(`SR5.Notifications.DeletingStorageReferences.Finished`)}`,
+        });
+        await MatrixNetworkFlow.handleOnDeleteDocument(actor);
+        // remove the progress bar now, we don't need to keep it around
+        progressBar.remove();
+    }
+}

--- a/src/module/helpers.ts
+++ b/src/module/helpers.ts
@@ -1143,14 +1143,14 @@ export class Helpers {
      * Transform uuid into a format that can be stored as keys in Foundry without object splitting.
      */
     static uuidForStorage(uuid: string) {
-        return uuid.replace('.', '_');
+        return uuid.replaceAll('.', '_');
     }
 
     /**
      * Reforms a transformed uuid back into a usable format.
      */
     static uuidFromStorage(uuid: string) {
-        return uuid.replace('_', '.');
+        return uuid.replaceAll('_', '.');
     }
 
     /**

--- a/src/module/item/SR5Item.ts
+++ b/src/module/item/SR5Item.ts
@@ -30,6 +30,7 @@ import { AttributeFieldType } from '../types/template/Attributes';
 import { RollDataOptions } from './Types';
 import { SetMarksOptions } from '../storage/MarksStorage';
 import { MatrixDeviceFlow } from './flows/MatrixDeviceFlow';
+import { StorageFlow } from '@/module/flows/StorageFlow';
 
 /**
  * Implementation of Shadowrun5e items (owned, unowned and nested).
@@ -1429,17 +1430,12 @@ export class SR5Item<SubType extends Item.ConfiguredSubType = Item.ConfiguredSub
         return super._preUpdate(changed, options, user);
     }
 
-    async deleteStorageReferences(this: SR5Item) {
-        await ItemMarksFlow.handleOnDeleteItem(this);
-        await MatrixNetworkFlow.handleOnDeleteDocument(this);
-    }
-
     /**
      * Handle system specific things before this item is deleted
      * @param args
      */
     override async _preDelete(...args: Parameters<Item["_preDelete"]>) {
-        await this.deleteStorageReferences();
+        await StorageFlow.deleteStorageReferences(this);
         return await super._preDelete(...args);
     }
 }

--- a/src/module/item/SR5Item.ts
+++ b/src/module/item/SR5Item.ts
@@ -1245,9 +1245,10 @@ export class SR5Item<SubType extends Item.ConfiguredSubType = Item.ConfiguredSub
     /**
      * Configure the given matrix item to be controlled by this item in a PAN/WAN.
      * @param slave The matrix item to be connected.
+     * @param options.triggerUpdates - trigger updates to the documents to rerender the sheets
      */
-    async addSlave(slave: SR5Actor | SR5Item) {
-        await MatrixNetworkFlow.addSlave(this, slave);
+    async addSlave(slave: SR5Actor | SR5Item, options?: { triggerUpdate?: boolean }) {
+        await MatrixNetworkFlow.addSlave(this, slave, options);
     }
 
     /**

--- a/src/module/item/flows/MatrixNetworkFlow.ts
+++ b/src/module/item/flows/MatrixNetworkFlow.ts
@@ -1,10 +1,10 @@
-import { SR5Actor } from "../../actor/SR5Actor";
-import { SR5Item } from "../SR5Item";
-import { NetworkStorage } from "../../storage/NetworkStorage";
-import { Helpers } from "../../helpers";
-import { SocketMessage } from "../../sockets";
-import { FLAGS, SYSTEM_NAME } from "../../constants";
-import { Translation } from "@/module/utils/strings";
+import { SR5Actor } from '../../actor/SR5Actor';
+import { SR5Item } from '../SR5Item';
+import { NetworkStorage } from '../../storage/NetworkStorage';
+import { Helpers } from '../../helpers';
+import { SocketMessage } from '../../sockets';
+import { FLAGS, SYSTEM_NAME } from '../../constants';
+import { Translation } from '@/module/utils/strings';
 
 /**
  * This flow handles everything involving how matrix devices are connected to network and what
@@ -58,8 +58,9 @@ export class MatrixNetworkFlow {
      *
      * @param master
      * @param slave
+     * @param options.triggerUpdates - trigger updates on the documents to rerender sheets
      */
-    static async addSlave(master: SR5Item, slave: SR5Actor | SR5Item) {
+    static async addSlave(master: SR5Item, slave: SR5Actor | SR5Item, options: { triggerUpdate?: boolean } = { triggerUpdate: true }) {
         console.debug(`Shadowrun5e | Adding document ${slave?.name} to the master ${master?.name}`, master, slave);
         if (!master || !slave) return console.error('Shadowrun 5e | Either the networks master or device did not resolve.');
 
@@ -70,7 +71,9 @@ export class MatrixNetworkFlow {
 
         console.debug(`Shadowrun5e | Added document ${slave?.name} to the master ${master?.name}`, master, slave);
 
-        await MatrixNetworkFlow._triggerUpdateForNetworkConnectionChange(master, slave);
+        if (options.triggerUpdate) {
+            await MatrixNetworkFlow._triggerUpdateForNetworkConnectionChange(master, slave);
+        }
 
         if (slave instanceof SR5Actor && master.isType('grid')) {
             await MatrixNetworkFlow.storeLastUsedGrid(slave, master);

--- a/src/module/item/flows/MatrixNetworkFlow.ts
+++ b/src/module/item/flows/MatrixNetworkFlow.ts
@@ -162,6 +162,8 @@ export class MatrixNetworkFlow {
         console.debug(`Shadowrun 5e | Removing all devices from network ${master.name}`);
 
         const slaves = NetworkStorage.getSlaves(master);
+        // if we don't have any slaves, skip the next parts
+        if (slaves.length === 0) return;
         await NetworkStorage.removeSlaves(master);
 
         // Since no document update occured, we have to trigger a update for cross session sheet re-render.

--- a/src/module/storage/MarksStorage.ts
+++ b/src/module/storage/MarksStorage.ts
@@ -129,12 +129,19 @@ export const MarksStorage = {
     async clearRelations(uuid: string) {
         const storage = MarksStorage.getStorage();
 
+        let changed = false;
         // Remove marks placed by.
         const uuidForStorage = MarksStorage._uuidForStorage(uuid);
-        delete storage[uuidForStorage];
+        if (storage[uuidForStorage]) {
+            changed = true;
+            delete storage[uuidForStorage];
+        }
 
         // Remove marks placed on.
         for (const [uuidForStorage, markRelations] of Object.entries(storage)) {
+            // if we don't include the id, skip this object
+            if (!markRelations.includes(uuid)) continue;
+            changed = true;
             storage[uuidForStorage] = markRelations.filter(markedUuid => markedUuid !== uuid);
 
             // Update lokal marks placed on the main uuid.
@@ -144,7 +151,9 @@ export const MarksStorage = {
             await document.clearMark(uuid);
         }
 
-        await DataStorage.set(MarksStorage.key, storage);
+        if (changed) {
+            await DataStorage.set(MarksStorage.key, storage);
+        }
     },
 
     /**

--- a/src/module/storage/NetworkStorage.ts
+++ b/src/module/storage/NetworkStorage.ts
@@ -78,11 +78,17 @@ export const NetworkStorage = {
         const networks = NetworkStorage.getStorage();
         const slaveUuid = Helpers.uuidForStorage(slave.uuid);
 
+        let changed = false;
         for (const [uuid, slaves] of Object.entries(networks)) {
-            networks[uuid] = slaves.filter(uuid => uuid !== slaveUuid);
+            if (slaves.includes(slaveUuid)) {
+                changed = true;
+                networks[uuid] = slaves.filter(uuid => uuid !== slaveUuid);
+            }
         }
 
-        await DataStorage.set(NetworkStorage.key, networks);
+        if (changed) {
+            await DataStorage.set(NetworkStorage.key, networks);
+        }
     },
 
     /**

--- a/src/module/token/SR5TokenDocument.ts
+++ b/src/module/token/SR5TokenDocument.ts
@@ -1,4 +1,5 @@
 import { MatrixNetworkFlow } from '@/module/item/flows/MatrixNetworkFlow';
+import { StorageFlow } from '@/module/flows/StorageFlow';
 
 export class SR5TokenDocument extends TokenDocument {
     /**
@@ -29,7 +30,7 @@ export class SR5TokenDocument extends TokenDocument {
     override async _preDelete(...args: Parameters<TokenDocument["_preDelete"]>) {
         // ensure we disconnect from any networks before being a token actor is deleted
         if (this.actor?.isToken) {
-            await this.actor.deleteStorageReferences();
+            await StorageFlow.deleteStorageReferences(this.actor);
         }
         return super._preDelete(...args);
     }

--- a/src/templates/actor/tabs/MiscTab.hbs
+++ b/src/templates/actor/tabs/MiscTab.hbs
@@ -13,8 +13,8 @@
                     {{/if}}
                     {{#if system.matrix.device}}
                     <div class="list-item-content">
-                        <button type="button" class="display setup-pan" data-tooltip="{{localize 'SR5.AddDevicesToPAN.SetupPANTooltip'}}">
-                            {{localize "SR5.AddDevicesToPAN.SetupPAN"}}
+                        <button type="button" class="display setup-pan" data-tooltip="{{localize 'SR5.Tooltips.Actor.SetupPAN'}}">
+                            {{localize "SR5.Labels.ActorSheet.SetupPAN"}}
                         </button>
                     </div>
                     {{/if}}


### PR DESCRIPTION
This was meant to speed up the deletion of actors as disconnecting all items can take some time. It now shows a progress bar to let users know what is happening.

During this, I found a bug in the way we were storing Mark data for token actors. I fixed that up as well.

Adding devices to your PAN is now much faster at the expense of not refreshing the items that are being updated. I think this is an okay sacrifice given the speed increase.