### PR TITLE
[Refactor] Improve robustness of LinksHelpers

### DIFF
--- a/src/module/utils/links.ts
+++ b/src/module/utils/links.ts
@@ -40,21 +40,20 @@ export class LinksHelpers {
         }
     }
 
+    // Field used to validate Foundry document UUIDs
+    private static readonly uuidField = new foundry.data.fields.DocumentUUIDField({ required: true });
+
     /**
-     * Determine if a given string is a valid Foundry document UUID.
-     * Uses the core `foundry.utils.parseUuid` utility for reliable detection.
+     * Check if the given string is a valid FoundryVTT document UUID.
+     * Uses Foundry's built-in DocumentUUIDField validation.
      *
-     * @param candidate The string that might be a UUID.
-     * @returns true, if the candidate is a valid UUID.
+     * @param candidate The string to check.
+     * @returns true if the candidate is a valid UUID, false otherwise.
      */
-    static isUuid(candidate: string | undefined) {
+    static isUuid(candidate: string | undefined): boolean {
         if (!candidate) return false;
 
-        try {
-            return !!foundry.utils.parseUuid(candidate).collection;
-        } catch (error) {
-            return false;
-        }
+        return this.uuidField.validate(candidate) === undefined;
     }
 
     /**

--- a/src/module/utils/links.ts
+++ b/src/module/utils/links.ts
@@ -1,5 +1,4 @@
 export interface PDFPager {
-    getPDFByCode: (pdfcode: string) => Promise<JournalEntryPage | undefined>;
     openPDFByCode: (pdfcode: string, options?: { page?: number; pdfcode?: string; showUuid?: boolean }) => void;
 }
 


### PR DESCRIPTION
Refactors the `LinksHelpers` utility to improve type safety, reliability, and handling of PDFs, URLs, and Foundry document UUIDs.

Changes:
- Updated `isPDF` to use a stricter regex pattern for validation.
- Improved `isURL` to properly parse URLs using `new URL()` while excluding PDFs and UUIDs.
- Refined `isUuid` to leverage Foundry's built-in `DocumentUUIDField` validation, providing more accurate and reliable UUID detection.
- Make sure that `openSourceURL` opens links in a new browser tab `(_blank)`.