### PR TITLE
fix: #1473 again class got lost. Fixes #1542.

### DIFF
--- a/src/templates/actor/tabs/SkillsTab.hbs
+++ b/src/templates/actor/tabs/SkillsTab.hbs
@@ -5,7 +5,7 @@
     <div class="inventory">
         <div class="split-container">
             {{> 'systems/shadowrun5e/dist/templates/actor/parts/skills/ActiveSkillList.hbs' }}
-            <div>
+            <div class="flexcol-skills">
                 {{> 'systems/shadowrun5e/dist/templates/actor/parts/attributes/SpecialAttributeList.hbs' }}
                 <div class="flexcontainer-skills">
                     {{> 'systems/shadowrun5e/dist/templates/actor/parts/skills/LanguageAndKnowledgeSkillList.hbs' }}


### PR DESCRIPTION
Fixes #1542 without resorting to the suggested hack. Just replicated the behaviour by readding the class from #1473 .