### PR TITLE
[Security] Proofing against prototype pollution

### DIFF
--- a/src/module/actor/SR5Actor.ts
+++ b/src/module/actor/SR5Actor.ts
@@ -73,12 +73,12 @@ export class SR5Actor<SubType extends Actor.ConfiguredSubType = Actor.Configured
         type: '',
         label: 'SR5.Labels.Inventory.Carried',
         itemIds: [],
-        showAll: true
+        showAll: false
     }
     // This is a dummy inventory
     allInventories: InventoryType = {
         name: 'All',
-        type: '',
+        type: 'all',
         label: 'SR5.Labels.Inventory.All',
         itemIds: [],
         showAll: true

--- a/src/module/actor/SR5Actor.ts
+++ b/src/module/actor/SR5Actor.ts
@@ -853,17 +853,17 @@ export class SR5Actor<SubType extends Actor.ConfiguredSubType = Actor.Configured
         const skills = rollData?.skills ?? this.getSkills();
 
         // Find skill by direct id to key matching.
-        if (skills.active.hasOwnProperty(id)) {
+        if (Object.hasOwn(skills.active, id)) {
             return skills.active[id];
         }
-        if (skills.language.value.hasOwnProperty(id)) {
+        if (Object.hasOwn(skills.language.value, id)) {
             return skills.language.value[id];
         }
         // Knowledge skills are de-normalized into categories (street, hobby, ...)
         for (const categoryKey in skills.knowledge) {
-            if (skills.knowledge.hasOwnProperty(categoryKey)) {
+            if (Object.hasOwn(skills.knowledge, categoryKey)) {
                 const category = skills.knowledge[categoryKey];
-                if (category.value.hasOwnProperty(id)) {
+                if (Object.hasOwn(category.value, id)) {
                     return category.value[id];
                 }
             }
@@ -893,7 +893,7 @@ export class SR5Actor<SubType extends Actor.ConfiguredSubType = Actor.Configured
 
         // Iterate over all different knowledge skill categories
         for (const categoryKey in skills.knowledge) {
-            if (!skills.knowledge.hasOwnProperty(categoryKey)) continue;
+            if (!Object.hasOwn(skills.knowledge, categoryKey)) continue;
             // TODO: check this function Typescript can't follow the flow here...
             const categorySkills = skills.knowledge[categoryKey].value as SkillFieldType[];
             for (const [id, skill] of Object.entries(categorySkills)) {
@@ -940,7 +940,7 @@ export class SR5Actor<SubType extends Actor.ConfiguredSubType = Actor.Configured
         category: KnowledgeSkillCategory,
         skill: Partial<SkillFieldType> = { name: SKILL_DEFAULT_NAME }
     ): Promise<string|undefined> {
-        if (!this.system.skills.knowledge.hasOwnProperty(category)) {
+        if (!Object.hasOwn(this.system.skills.knowledge, category)) {
             console.error(`Shadowrun5e | Tried creating knowledge skill with unknown category ${category}`);
             return;
         }
@@ -1033,7 +1033,7 @@ export class SR5Actor<SubType extends Actor.ConfiguredSubType = Actor.Configured
      */
     async removeActiveSkill(skillId: string) {
         const activeSkills = this.getActiveSkills();
-        if (!activeSkills.hasOwnProperty(skillId)) return;
+        if (!Object.hasOwn(activeSkills, skillId)) return;
         const skill = this.getSkill(skillId);
         if (!skill) return;
 
@@ -1354,7 +1354,7 @@ export class SR5Actor<SubType extends Actor.ConfiguredSubType = Actor.Configured
      * @param attribute
      */
     _isMatrixAttribute(attribute: string): boolean {
-        return SR5.matrixAttributes.hasOwnProperty(attribute);
+        return Object.hasOwn(SR5.matrixAttributes, attribute);
     }
 
     /**

--- a/src/module/actor/flows/InventoryFlow.ts
+++ b/src/module/actor/flows/InventoryFlow.ts
@@ -24,7 +24,7 @@ export class InventoryFlow {
     constructor(actor: SR5Actor) {
         // Check for sub-type actors.
         // NOTE: This should be checked through actor.system.modelProvider, though this doesn´t exist sometimes?
-        if (actor.type.includes('.') || !game.model.Actor.hasOwnProperty(actor.type)) {
+        if (actor.type.includes('.') || !Object.hasOwn(game.model.Actor, actor.type)) {
             console.debug(`Shadowrun 5e | InventoryFlow ignored actor ${actor.name} as it has a non-system DataModel`);
             return;
         }

--- a/src/module/actor/flows/TeamworkFlow.ts
+++ b/src/module/actor/flows/TeamworkFlow.ts
@@ -128,7 +128,7 @@ export class TeamworkTest {
      * @returns 
      */
     static async _handleUpdateSocketMessage(socketMessage: Shadowrun.SocketMessageData) {
-        if (!socketMessage.data.hasOwnProperty('messageUuid') || !socketMessage.data.hasOwnProperty('content') || !socketMessage.data.hasOwnProperty('teamworkData')) {
+        if (!Object.hasOwn(socketMessage.data, 'messageUuid') || !Object.hasOwn(socketMessage.data, 'content') || !Object.hasOwn(socketMessage.data, 'teamworkData')) {
             console.error(`Shadowrun 5e | Teamwork Socket Message is missing necessary properties`, socketMessage);
             return;
         }

--- a/src/module/actor/prep/ICPrep.ts
+++ b/src/module/actor/prep/ICPrep.ts
@@ -104,7 +104,7 @@ export class ICPrep {
         const { attributes, host } = system;
 
         for (const id of Object.keys(SR5.attributes)) {
-            if (!attributes.hasOwnProperty(id)) continue;
+            if (!Object.hasOwn(attributes, id)) continue;
             // Exclude invalid attributes for IC
             if (['magic', 'edge', 'essence', 'resonance'].includes(id)) continue
 
@@ -129,7 +129,7 @@ export class ICPrep {
         const { matrix } = system;
 
         for (const id of Object.keys(SR5.matrixAttributes)) {
-            if (!matrix.hasOwnProperty(id)) continue;
+            if (!Object.hasOwn(matrix, id)) continue;
 
             const attribute = matrix[id];
             AttributesPrep.prepareAttribute(id, attribute);

--- a/src/module/actor/prep/functions/AttributesPrep.ts
+++ b/src/module/actor/prep/functions/AttributesPrep.ts
@@ -32,7 +32,7 @@ export class AttributesPrep {
      */
     static prepareAttribute(name: string, attribute: AttributeFieldType, ranges?: Record<string, {min: number, max?: number}>) {
         // Check for valid attributes. Active Effects can cause unexpected properties to appear.
-        if (!SR5.attributes.hasOwnProperty(name) || !attribute) return;
+        if (!Object.hasOwn(SR5.attributes, name) || !attribute) return;
 
         // Each attribute can have a unique value range.
         // TODO:  Implement metatype attribute value ranges for character actors.
@@ -50,7 +50,7 @@ export class AttributesPrep {
      */
     static calculateAttribute(name: string, attribute: AttributeFieldType, ranges?: Record<string, {min: number, max?: number}>) {
         // Check for valid attributes. Active Effects can cause unexpected properties to appear.
-        if (!SR5.attributes.hasOwnProperty(name) || !attribute) return;
+        if (!Object.hasOwn(SR5.attributes, name) || !attribute) return;
 
         // Each attribute can have a unique value range.
         // TODO:  Implement metatype attribute value ranges for character actors.

--- a/src/module/actor/prep/functions/ItemPrep.ts
+++ b/src/module/actor/prep/functions/ItemPrep.ts
@@ -19,7 +19,8 @@ export class ItemPrep {
         }
 
         const armorModParts = new PartsList<number>(armor.mod);
-        const equippedArmor = items.filter((item) => item.isType('armor') && item.isEquipped()) as SR5Item<'armor'>[];
+        // NOTE: We retrieve different types of items, all containing armor data.
+        const equippedArmor = items.filter((item) => item.hasArmor() && item.isEquipped()) as SR5Item<'armor'>[];
         equippedArmor?.forEach((item) => {
             const armorValue = item.system.armor.value;
             // Don't spam armor values with clothing or armor like items without any actual armor.

--- a/src/module/actor/prep/functions/MatrixPrep.ts
+++ b/src/module/actor/prep/functions/MatrixPrep.ts
@@ -97,7 +97,7 @@ export class MatrixPrep {
 
         // add matrix attributes to both limits and attributes as hidden entries
         Object.keys(SR5.matrixAttributes).forEach((attributeName) => {
-            if (!matrix.hasOwnProperty(attributeName)) {
+            if (!Object.hasOwn(matrix, attributeName)) {
                 return console.error(`SR5Actor matrix preparation failed due to missing matrix attributes`);
             }
 

--- a/src/module/actor/prep/functions/ModifiersPrep.ts
+++ b/src/module/actor/prep/functions/ModifiersPrep.ts
@@ -5,7 +5,7 @@ export class ModifiersPrep {
         const { attributes } = system;
         for (const [name, attribute] of Object.entries(attributes)) {
             // Check for valid attributes. Active Effects can cause unexpected properties to appear.
-            if (!SR5.attributes.hasOwnProperty(name) || !attribute) return;
+            if (!Object.hasOwn(SR5.attributes, name) || !attribute) return;
 
             attribute.mod = [];
         }
@@ -20,7 +20,7 @@ export class ModifiersPrep {
     static clearLimitMods(system: Actor.SystemOfType<'character' | 'critter' | 'spirit' | 'sprite' | 'vehicle'>) {
         const {limits} = system;
         for (const [name, limit] of Object.entries(limits)) {
-            if (!SR5.limits.hasOwnProperty(name) || !limit) return;
+            if (!Object.hasOwn(SR5.limits, name) || !limit) return;
 
             limit.mod = [];
         }

--- a/src/module/actor/sheets/SR5BaseActorSheet.ts
+++ b/src/module/actor/sheets/SR5BaseActorSheet.ts
@@ -441,7 +441,7 @@ export class SR5BaseActorSheet extends foundry.appv1.sheets.ActorSheet {
      */
     _addInventoryTypes(inventory: InventorySheetData) {
         for (const type of this.getInventoryItemTypes()) {
-            if (inventory.types.hasOwnProperty(type)) continue;
+            if (Object.hasOwn(inventory.types, type)) continue;
 
             inventory.types[type] = {
                 type,
@@ -990,7 +990,7 @@ export class SR5BaseActorSheet extends foundry.appv1.sheets.ActorSheet {
             const { name, label, itemIds } = inventory;
 
             // Avoid re-adding default inventories.
-            if (!inventoriesSheet.hasOwnProperty(name)) {
+            if (!Object.hasOwn(inventoriesSheet, name)) {
                 inventoriesSheet[name] = {
                     name,
                     label,

--- a/src/module/apps/SituationModifiersApplication.ts
+++ b/src/module/apps/SituationModifiersApplication.ts
@@ -199,7 +199,7 @@ class RecoilModifiersHandler extends ModifiersHandler {
         // Expect the element group to siblings.
         // Triggering DOMElement should contain the delta...
         const triggerElement = event.target;
-        if (!triggerElement || !triggerElement.dataset.hasOwnProperty('delta')) 
+        if (!triggerElement || !Object.hasOwn(triggerElement.dataset, 'delta')) 
             return console.error('Shadowrun5e | Expected a DOMElement with a different structure');
 
         const delta = Number(triggerElement.dataset['delta']);
@@ -337,7 +337,7 @@ export class SituationModifiersApplication extends foundry.appv1.api.FormApplica
         // Expect the element group to siblings.
         // Triggering DOMElement should contain the delta...
         const triggerElement = event.target;
-        if (!triggerElement || !triggerElement.dataset.hasOwnProperty('delta')) 
+        if (!triggerElement || !Object.hasOwn(triggerElement.dataset, 'delta')) 
             return console.error('Shadowrun5e | Expected a DOMElement with a different structure');
 
         const delta = Number(triggerElement.dataset['delta']);

--- a/src/module/apps/dialogs/TestDialog.ts
+++ b/src/module/apps/dialogs/TestDialog.ts
@@ -135,7 +135,7 @@ export class TestDialog extends FormDialog {
         Object.entries(data).forEach(([key, value]) => {
             // key is expected to be relative from TestDialog.data and begin with 'test'
             const valueField = foundry.utils.getProperty(this.data, key) as ModifiableValueType | undefined | null;
-            if (!valueField || foundry.utils.getType(valueField) !== 'Object' || !valueField.hasOwnProperty('mod')) return;
+            if (!valueField || foundry.utils.getType(valueField) !== 'Object' || !Object.hasOwn(valueField, 'mod')) return;
 
             // Remove from further automatic data merging.
             delete data[key];

--- a/src/module/combat/SR5Combat.ts
+++ b/src/module/combat/SR5Combat.ts
@@ -439,7 +439,7 @@ export class SR5Combat<SubType extends Combat.SubType = Combat.SubType> extends 
     }
 
     static async _handleDoNextRoundSocketMessage(message: SocketMessageData) {
-        if (!message.data.hasOwnProperty('id') && typeof message.data.id !== 'string') {
+        if (!Object.hasOwn(message.data, 'id') && typeof message.data.id !== 'string') {
             console.error(`SR5Combat Socket Message ${FLAGS.DoNextRound} data.id must be a string (combat id) but is ${typeof message.data} (${message.data})!`);
             return;
         }
@@ -448,7 +448,7 @@ export class SR5Combat<SubType extends Combat.SubType = Combat.SubType> extends 
     }
 
     static async _handleDoInitPassSocketMessage(message: SocketMessageData) {
-        if (!message.data.hasOwnProperty('id') && typeof message.data.id !== 'string') {
+        if (!Object.hasOwn(message.data, 'id') && typeof message.data.id !== 'string') {
             console.error(`SR5Combat Socket Message ${FLAGS.DoInitPass} data.id must be a string (combat id) but is ${typeof message.data} (${message.data})!`);
             return;
         }
@@ -461,7 +461,7 @@ export class SR5Combat<SubType extends Combat.SubType = Combat.SubType> extends 
      * @param message 
      */
     static async _handleDoNewActionPhaseSocketMessage(message: SocketMessageData) {
-        if (!message.data.hasOwnProperty('id') && typeof message.data.id !== 'string') {
+        if (!Object.hasOwn(message.data, 'id') && typeof message.data.id !== 'string') {
             console.error(`SR5Combat Socket Message ${FLAGS.DoNewActionPhase} data.id must be a string (combat id) but is ${typeof message.data} (${message.data})!`);
             return;
         }

--- a/src/module/effect/flows/SuccessTestEffectsFlow.ts
+++ b/src/module/effect/flows/SuccessTestEffectsFlow.ts
@@ -227,7 +227,7 @@ export class SuccessTestEffectsFlow<T extends SuccessTest> {
      * @returns 
      */
     static async _handleCreateTargetedEffectsSocketMessage(message: Shadowrun.SocketMessageData) {
-        if (!message.data.hasOwnProperty('actorUuid') && !message.data.hasOwnProperty('effectsData')) {
+        if (!Object.hasOwn(message.data, 'actorUuid') && !Object.hasOwn(message.data, 'effectsData')) {
             console.error(`Shadowrun 5e | ${this.name} Socket Message is missing necessary properties`, message);
             return;
         }

--- a/src/module/handlebars/BasicHelpers.ts
+++ b/src/module/handlebars/BasicHelpers.ts
@@ -66,7 +66,7 @@ export const registerBasicHelpers = () => {
         return v1 / v2;
     });
     Handlebars.registerHelper('hasprop', function (this: any, obj, prop, options) {
-        if (obj.hasOwnProperty(prop)) {
+        if (Object.hasOwn(obj, prop)) {
             return options.fn(this);
         } else return options.inverse(this);
     });

--- a/src/module/handlebars/SkillLineHelpers.ts
+++ b/src/module/handlebars/SkillLineHelpers.ts
@@ -47,7 +47,7 @@ export const registerSkillLineHelpers = () => {
         // Display filters for active skills. See issue #871.
         // when not given, filters won't be undefined, but will contain a handlebar object.
         const activeSkillFilter = id === 'active' &&
-            filters && filters.hasOwnProperty('showUntrainedSkills') &&
+            filters && Object.hasOwn(filters, 'showUntrainedSkills') &&
             !filters.showUntrainedSkills;
 
         const rtg = {

--- a/src/module/helpers.ts
+++ b/src/module/helpers.ts
@@ -281,7 +281,7 @@ export class Helpers {
 
     static addLabels(obj, label) {
         if (typeof obj === 'object' && obj !== null) {
-            if (!obj.hasOwnProperty('label') && obj.hasOwnProperty('value') && label !== '') {
+            if (!Object.hasOwn(obj, 'label') && Object.hasOwn(obj, 'value') && label !== '') {
                 obj.label = label;
             }
             Object.entries(obj)
@@ -428,7 +428,7 @@ export class Helpers {
     static convertLengthUnit(length: number, fromUnit: string): number {
         fromUnit = fromUnit.toLowerCase();
 
-        if (!LENGTH_UNIT_TO_METERS_MULTIPLIERS.hasOwnProperty(fromUnit)) {
+        if (!Object.hasOwn(LENGTH_UNIT_TO_METERS_MULTIPLIERS, fromUnit)) {
             console.error(`Distance can't be converted from ${fromUnit} to ${LENGTH_UNIT}`);
             return 0;
         }
@@ -925,7 +925,7 @@ export class Helpers {
      */
     static objectHasKeys(obj: object, keys: string[]): boolean {
         for (const key of keys) {
-            if (!obj.hasOwnProperty(key)) return false;
+            if (!Object.hasOwn(obj, key)) return false;
         }
 
         return true;

--- a/src/module/item/SR5Item.ts
+++ b/src/module/item/SR5Item.ts
@@ -1011,6 +1011,16 @@ export class SR5Item<SubType extends Item.ConfiguredSubType = Item.ConfiguredSub
     }
 
     /**
+     * Determine if this item can contain armor.
+     * This can happen both for actual armor and items containing armor data.
+     * @returns true, if this item can provide armor values.
+     */
+    hasArmor(this: SR5Item) {
+        const armor = this.system.armor;
+        return this.isType('armor') || !!armor;
+    }
+
+    /**
      * Amount of current recoil left after recoil compensation.
      */
     get unhandledRecoil(): number {

--- a/src/module/item/SR5Item.ts
+++ b/src/module/item/SR5Item.ts
@@ -1121,7 +1121,7 @@ export class SR5Item<SubType extends Item.ConfiguredSubType = Item.ConfiguredSub
     }
 
     get _isNestedItem(): boolean {
-        return this.hasOwnProperty('parent') && this.parent instanceof SR5Item;
+        return Object.hasOwn(this, 'parent') && this.parent instanceof SR5Item;
     }
 
     /**

--- a/src/module/migrator/Migrator.ts
+++ b/src/module/migrator/Migrator.ts
@@ -1,3 +1,4 @@
+import { Version0_30_3 } from './versions/Version0_30_3';
 import { FLAGS } from "../constants";
 import { Sanitizer } from "../sanitizer/Sanitizer";
 import { Version0_8_0 } from "./versions/Version0_8_0";
@@ -36,6 +37,7 @@ export class Migrator {
         new Version0_16_0(),
         new Version0_27_0(),
         new Version0_30_0(),
+        new Version0_30_3(),
     ] as const;
 
     private static documentsToBeMigrated: number = 0;

--- a/src/module/migrator/versions/Version0_30_3.ts
+++ b/src/module/migrator/versions/Version0_30_3.ts
@@ -1,0 +1,29 @@
+import { VersionMigration } from "../VersionMigration";
+
+/**
+ */
+export class Version0_30_3 extends VersionMigration {
+    readonly TargetVersion = "0.30.3";
+
+    override handlesActor(_actor: Readonly<any>) {
+        // Inventory should exist on all actors, but we're being cautious.
+        if (_actor.system.inventories) return true;
+        return false;
+    }
+
+    override migrateActor(_actor: any): void {
+        this._migrateNonAllInventories(_actor);
+    }
+
+    /**
+     * Due to an issue with default inventory data setting showAll to true, newly created inventories, 
+     * as well as default 'carried', since 0.30.0 would break display of which inventory an item belongs to.
+     */
+    _migrateNonAllInventories(_actor: any) {
+        for (const inventory of Object.values<any>(_actor.system.inventories)) {
+            if (inventory.name === 'All') continue;
+
+            _actor.system.inventories[inventory.name].showAll = false;
+        }
+    }
+}

--- a/src/module/rules/AttributeRules.ts
+++ b/src/module/rules/AttributeRules.ts
@@ -62,10 +62,10 @@ export class AttributeRules {
      */
     static replacePhysicalAttributesWithMentalAttributes(action: MinimalActionType) {
         // check the attributes used by the action
-        if (this.PhysicalToMentalAttributeMap.hasOwnProperty(action.attribute)) {
+        if (Object.hasOwn(this.PhysicalToMentalAttributeMap, action.attribute)) {
             action.attribute = this.PhysicalToMentalAttributeMap[action.attribute];
         }
-        if (this.PhysicalToMentalAttributeMap.hasOwnProperty(action.attribute2)) {
+        if (Object.hasOwn(this.PhysicalToMentalAttributeMap, action.attribute2)) {
             action.attribute2 = this.PhysicalToMentalAttributeMap[action.attribute2];
         }
     }

--- a/src/module/rules/DocumentSituationModifiers.ts
+++ b/src/module/rules/DocumentSituationModifiers.ts
@@ -132,7 +132,7 @@ export class DocumentSituationModifiers {
      * @returns true, when a total modifier can be calculated by a handler.
      */
     handlesTotalFor(category: string) {
-        return this._modifiers.hasOwnProperty(category);
+        return Object.hasOwn(this._modifiers, category);
     }
 
     /**
@@ -181,7 +181,7 @@ export class DocumentSituationModifiers {
         data = foundry.utils.duplicate(data);
 
         for (const [category, modifiers] of Object.entries(DocumentSituationModifiers._defaultModifiers)) {
-            if (!data.hasOwnProperty(category)) data[category] = modifiers;
+            if (!Object.hasOwn(data, category)) data[category] = modifiers;
         }
 
         return data as SituationModifiersSourceData;
@@ -271,7 +271,7 @@ export class DocumentSituationModifiers {
     static async clearTypeOn(document: ModifiableDocumentTypes, category: keyof SituationModifiersSourceData): Promise<DocumentSituationModifiers> {
         const modifiers = DocumentSituationModifiers.getDocumentModifiers(document);
 
-        if (!modifiers.source.hasOwnProperty(category)) return modifiers;
+        if (!Object.hasOwn(modifiers.source, category)) return modifiers;
         modifiers.source[category] = DocumentSituationModifiers._defaultModifier;
 
         await DocumentSituationModifiers.setDocumentModifiers(document, modifiers.source);

--- a/src/module/rules/modifiers/SituationModifier.ts
+++ b/src/module/rules/modifiers/SituationModifier.ts
@@ -132,14 +132,14 @@ export class SituationModifier {
      * Determine if a fixed value has been set.
      */
     get hasFixed(): boolean {
-        return this.applied.hasOwnProperty('fixed');
+        return Object.hasOwn(this.applied, 'fixed');
     }
 
     /**
      * Determine if a fixed user selection has been made.
      */
     get hasFixedSelection(): boolean {
-        return this.applied.active.hasOwnProperty('value');
+        return Object.hasOwn(this.applied.active, 'value');
     }
 
     /**
@@ -189,7 +189,7 @@ export class SituationModifier {
      * @param modifier The possibly active modifier to check
      */
     isActive(modifier: string) {
-        return this.source.active.hasOwnProperty(modifier);
+        return Object.hasOwn(this.source.active, modifier);
     }
 
     /**

--- a/src/module/tests/TestCreator.ts
+++ b/src/module/tests/TestCreator.ts
@@ -79,7 +79,7 @@ export const TestCreator = {
             console.warn(`Shadowrun 5e | An action without a defined test handler defaulted to ${'SuccessTest'}`);
         }
 
-        if (!game.shadowrun5e.tests.hasOwnProperty(action.test)) {
+        if (!Object.hasOwn(game.shadowrun5e.tests, action.test)) {
             console.error(`Shadowrun 5e | Test registration for test ${action.test} is missing`);
             return;
         }
@@ -106,7 +106,7 @@ export const TestCreator = {
             console.warn(`Shadowrun 5e | An action without a defined test handler defaulted to ${'SuccessTest'}`);
         }
 
-        if (!game.shadowrun5e.tests.hasOwnProperty(action.test)) {
+        if (!Object.hasOwn(game.shadowrun5e.tests, action.test)) {
             console.error(`Shadowrun 5e | Test registration for test ${action.test} is missing`);
             return;
         }
@@ -330,7 +330,7 @@ export const TestCreator = {
      */
     _getTestClass: function(testName: string): any | undefined {
         if (!testName) return;
-        if (!game.shadowrun5e.tests.hasOwnProperty(testName)) {
+        if (!Object.hasOwn(game.shadowrun5e.tests, testName)) {
             console.error(`Shadowrun 5e | Tried getting a Test Class ${testName}, which isn't registered in: `, game.shadowrun5e.tests);
             return;
         }
@@ -657,7 +657,7 @@ export const TestCreator = {
      * @returns true for when the original action value should be kept, false if it's to be overwritten.
      */
     _keepItemActionValue(action: ActionRollType, defaultAction: DeepPartial<MinimalActionType>, key: string): boolean {
-        if (!defaultAction.hasOwnProperty(key)) return true;
+        if (!Object.hasOwn(defaultAction, key)) return true;
 
         // Avoid user confusion. A user might change one value of a logical value grouping (skill+attribute)
         // and get a default value for the other. 
@@ -683,7 +683,7 @@ export const TestCreator = {
      * @returns false, when the value behind key is a default value. true, when it's a custom value.
      */
     _actionHasNoneDefaultValue(action: ActionRollType, key: string): boolean {
-        if (!action.hasOwnProperty(key)) return false;
+        if (!Object.hasOwn(action, key)) return false;
 
         // NOTE: A more complete comparison would take a default ActionRollData object and compare the sub-key against it.
         const value = action[key];

--- a/src/module/tests/flows/MatrixTestDataFlow.ts
+++ b/src/module/tests/flows/MatrixTestDataFlow.ts
@@ -50,7 +50,7 @@ export const MatrixTestDataFlow = {
      * @param attribute
      */
     isMatrixAttribute(attribute: string): boolean {
-        return SR5.matrixAttributes.hasOwnProperty(attribute);
+        return Object.hasOwn(SR5.matrixAttributes, attribute);
     },
 
     /**

--- a/src/module/types/actor/Common.ts
+++ b/src/module/types/actor/Common.ts
@@ -50,7 +50,7 @@ const InventoryData = () => ({
     name: new StringField({ required: true }),
     type: new StringField({ required: true }),
     itemIds: new ArrayField(new StringField({ required: true })),
-    showAll: new BooleanField({ initial: true }),
+    showAll: new BooleanField({ initial: false }),
     label: new StringField({ required: true }),
 });
 

--- a/system.json
+++ b/system.json
@@ -21,7 +21,7 @@
         }
     ],
     "url": "#{URL}#",
-    "version": "0.30.0",
+    "version": "0.30.3",
     "compatibility": {
         "minimum": "13",
         "verified": "13.347",


### PR DESCRIPTION
This PR replaces all unsafe direct calls to `.hasOwnProperty()` with the more modern safer `Object.hasOwn()` approach across the codebase.

### Method of implementation

```bash
find src -type f -name "*.ts" -exec sed -E -i 's/([a-zA-Z0-9_$.]+)\.hasOwnProperty\(([^)]+)\)/Object.hasOwn(\1, \2)/g' {} +
```

### Why this matters:
Directly calling `x.hasOwnProperty(...)` can be exploited through prototype pollution, especially when dealing with objects that can receive external input. Using `Object.hasOwn(x, ...)` should ensure the check is safe even if the object’s prototype has been modified.

#### Important notes / remaining risk:
The following files were not modified on the request of @BM123499 and still contain direct `.hasOwnProperty` usage. They remain potential vectors for prototype pollution.

```md
apps/itemImporter/importer/
  - ComplexFormImporter.ts
  - CritterImporter.ts
  - CritterPowerImporter.ts
  - EchoesImporter.ts
  - GearImporter.ts
  - QualityImporter.ts
  - SpellImporter.ts
  - VehicleImporter.ts
  - VehicleModImporter.ts
  - WareImporter.ts
  - WeaponImporter.ts
  - WeaponModImporter.ts
  ```