### PR TITLE
[BUG] Silent Matrix icons are still visible through target list

### DIFF
--- a/src/module/actor/SR5Actor.ts
+++ b/src/module/actor/SR5Actor.ts
@@ -1985,7 +1985,7 @@ export class SR5Actor<SubType extends Actor.ConfiguredSubType = Actor.Configured
     /**
      * Retrieve all matrix devices of this actor that are equipped and set to wireless.
      */
-    get wirelessDevices() {
+    get wirelessDevices(): SR5Item[] {
         return this.items.filter(item => item.isMatrixDevice && item.isEquipped() && item.isWireless());
     }
 

--- a/src/module/actor/SR5Actor.ts
+++ b/src/module/actor/SR5Actor.ts
@@ -1985,11 +1985,11 @@ export class SR5Actor<SubType extends Actor.ConfiguredSubType = Actor.Configured
     /**
      * Retrieve all matrix devices of this actor that are equipped and set to wireless.
      */
-    get wirelessDevices(): SR5Item[] {
+    wirelessDevices() {
         return this.items.filter(item => item.isMatrixDevice && item.isEquipped() && item.isWireless());
     }
 
-    get hasWirelessDevices() {
+    hasWirelessDevices() {
         return this.wirelessDevices.length > 0;
     }
 

--- a/src/module/actor/sheets/SR5MatrixActorSheet.ts
+++ b/src/module/actor/sheets/SR5MatrixActorSheet.ts
@@ -98,7 +98,7 @@ export class SR5MatrixActorSheet extends SR5BaseActorSheet {
         for (const target of targets) {
             // Collect connected icons, if user wants to see them.
             if (this._connectedIconsOpenClose[target.document.uuid]) {
-                target.icons = MatrixTargetingFlow.getConnectedMatrixIconTargets(target.document as SR5Actor);
+                target.icons = MatrixTargetingFlow.getWirelessMatrixIconTargets(target.document as SR5Actor);
 
                 for (const icon of target.icons) {
                     // Mark icon as selected.
@@ -475,7 +475,7 @@ export class SR5MatrixActorSheet extends SR5BaseActorSheet {
                 // An already marked icon will again show up when all icons are collected.
                 // So we can simply overwrite all icons here without any filtering.
 
-                target.icons = MatrixTargetingFlow.getConnectedMatrixIconTargets(target.document as SR5Actor);
+                target.icons = MatrixTargetingFlow.getWirelessMatrixIconTargets(target.document as SR5Actor);
 
                 for (const icon of target.icons) {
                     // Mark icon as selected.

--- a/src/module/flows/MatrixTargetingFlow.ts
+++ b/src/module/flows/MatrixTargetingFlow.ts
@@ -209,11 +209,10 @@ export const MatrixTargetingFlow = {
     /**
      * Collect matrix icons connected to the document given by uuid.
      * 
-     * TODO: Look into MarkPlacementFlow_prepareActorDevices and merge functionality.
-     * @param document 
-     * @returns List of matrix icons connected to the document.
+     * @param document Retrieve icons connected to this document.
+     * @returns List of matrix icons that can be targeted wirelessly.
      */
-    getConnectedMatrixIconTargets(document: SR5Actor) {
+    getWirelessMatrixIconTargets(document: SR5Actor) {
         const connectedIcons: Shadowrun.MarkedDocument[] = [];
 
         // Only persona icons should show connected icons.
@@ -223,6 +222,7 @@ export const MatrixTargetingFlow = {
         for (const device of document.wirelessDevices) {
             // Persona devices don't have their own device icon.
             if (personaDevice && device.uuid === personaDevice.uuid) continue;
+            if (device.isRunningSilent()) continue;
 
             connectedIcons.push({
                 name: Helpers.getChatSpeakerName(device),

--- a/src/module/flows/MatrixTargetingFlow.ts
+++ b/src/module/flows/MatrixTargetingFlow.ts
@@ -219,7 +219,7 @@ export const MatrixTargetingFlow = {
         if (!(document instanceof SR5Actor)) return connectedIcons;
 
         const personaDevice = document.getMatrixDevice();
-        for (const device of document.wirelessDevices) {
+        for (const device of document.wirelessDevices()) {
             // Persona devices don't have their own device icon.
             if (personaDevice && device.uuid === personaDevice.uuid) continue;
             if (device.isRunningSilent()) continue;

--- a/src/module/handlebars/ItemLineHelpers.ts
+++ b/src/module/handlebars/ItemLineHelpers.ts
@@ -1128,7 +1128,7 @@ export const registerItemLineHelpers = () => {
             };
 
         const icons: any = [];
-        if (target.document instanceof SR5Actor && target.document.hasWirelessDevices) icons.push(toggleConnectedItemsIcon);
+        if (target.document instanceof SR5Actor && target.document.hasWirelessDevices()) icons.push(toggleConnectedItemsIcon);
 
         // if there are no icons, add an empty object to the list so that the columns match up correctly
         if (icons.length === 0) icons.push({});
@@ -1177,7 +1177,7 @@ export const registerItemLineHelpers = () => {
 
         // Handle document type specific icons.
         if (target.document instanceof SR5Item && target.document.isNetwork()) icons.unshift(connectNetworkIcon);
-        if (target.document instanceof SR5Actor && target.document.hasWirelessDevices) icons.push(toggleConnectedItemsIcon)
+        if (target.document instanceof SR5Actor && target.document.hasWirelessDevices()) icons.push(toggleConnectedItemsIcon)
 
         return icons;
     });
@@ -1234,7 +1234,7 @@ export const registerItemLineHelpers = () => {
                     : 'SR5.WirelessOnline')
         }
         if (target.document instanceof SR5Actor) {
-            return target.document.hasWirelessDevices ? [wirelessIcon, toggleConnectedItemsIcon] : [wirelessIcon];
+            return target.document.hasWirelessDevices() ? [wirelessIcon, toggleConnectedItemsIcon] : [wirelessIcon];
         }
         return [wirelessIcon];
     });

--- a/src/module/tests/flows/MatrixTestDataFlow.ts
+++ b/src/module/tests/flows/MatrixTestDataFlow.ts
@@ -383,7 +383,7 @@ export const MatrixTestDataFlow = {
         if (!test.persona.isType('character', 'critter', 'vehicle')) return;
 
         // Collect network devices
-        test.devices = test.persona.wirelessDevices;
+        test.devices = test.persona.wirelessDevices();
     },
 
     /**


### PR DESCRIPTION
Fixes #1552

Previously all wireless devices were collected for targeting. 

The icon targeting approach is still very prototypi'. While adding an additional `isRunningSilent` check will remove those icons from targeting, the additional `runningSilent` property is likely unused for now.

It was originally part of a genereric approach of collecting marked documents, which is reused here for targeted documents (which might also be marked). This causes duplicate data to be present.

I've added a task to the Matrix 2.0 board to clean this up.

An additional requirement for matrix targets will be a GM and player flow that allows players to hack non-wireless targets using a direct connection. Added another task to the Matrix 2.0 board.