### PR TITLE
[BUG] Player Grid Hopping Doesnt Update On GM Side

### DIFF
--- a/src/module/item/flows/MatrixNetworkFlow.ts
+++ b/src/module/item/flows/MatrixNetworkFlow.ts
@@ -223,6 +223,9 @@ export class MatrixNetworkFlow {
         await NetworkStorage.removeFromNetworks(slave);
         await MatrixNetworkFlow._triggerUpdateForNetworkConnectionChange(master, slave);
 
+        // Cause rerender of sheets across all user sessions.
+        await slave.update({system: {matrix: {updatedConnections: Date.now()}}});        
+
         // Reconnect to previously used grid, if any.
         if (slave instanceof SR5Item || !(master instanceof SR5Item)) return;
         await MatrixNetworkFlow.reconnectToLastGrid(slave, master);

--- a/src/module/types/template/Matrix.ts
+++ b/src/module/types/template/Matrix.ts
@@ -58,7 +58,12 @@ export const MatrixData = () => ({
     running_silent: new BooleanField(),
     item: new AnyField({ required: false }),
     marks: MatrixMarksTarget(),
-    grid: new SchemaField(LastGridData())
+    grid: new SchemaField(LastGridData()),
+    // Helper data point to indicate a network connection update.
+    // This is not storing data that's used anywhere but rather is used
+    // to trigger sheet renders across all user sessions when this actors
+    // network connection is updated. The connection itself is stored in DataStorage.
+    updatedConnections: new NumberField({ required: true, nullable: false, integer: true, initial: 0 })
 })
 
 export type MatrixType = foundry.data.fields.SchemaField.InitializedData<ReturnType<typeof MatrixData>>;

--- a/src/module/types/template/MatrixNetwork.ts
+++ b/src/module/types/template/MatrixNetwork.ts
@@ -6,7 +6,7 @@ const { NumberField, BooleanField } = foundry.data.fields;
 export const MatrixDeviceData = () => ({
     // Helper data point to indicate a network connection update.
     // This is not storing data that's used anywhere but rather is used
-    // to trigger sheet renders across all user sessions when this actors
+    // to trigger sheet renders across all user sessions when this items
     // network connection is updated. The connection itself is stored in DataStorage.
     updatedConnections: new NumberField({ required: true, nullable: false, integer: true, initial: 0 })
 });


### PR DESCRIPTION
Fixes #1591

Issue is related to network connections being stored in `DataStorage` instead of on document. We've had the same issue with PAN / WAN devices and their shown connected icons not updating across user sessions.

I've used the same solution here - updating a dummy system field -, though this will not update unrelated sheets any user could have open for any actor which might be in any way showing the updated actors network state. For those, we'd have to use another approch, which I added my first thought to here: https://github.com/users/SR5-FoundryVTT/projects/3/views/5?sliceBy%5Bvalue%5D=To+do&pane=issue&itemId=130977972

Until then, the "Refresh"-button must be used for all other actors to update their icons list.