### PR TITLE
[Feature] Adds Drones Categories for Anthro Track

### DIFF
--- a/public/locale/en/config.json
+++ b/public/locale/en/config.json
@@ -1662,6 +1662,17 @@
         "UseEdgeForInitiativeRoll": "Use edge rule blitz for initiative",
         "Value": "Value",
         "Vehicle": {
+            "Category": "Category",
+            "Categories": {
+                "Micro": "Micro",
+                "Mini": "Mini",
+                "Small": "Small",
+                "Medium": "Medium",
+                "Large": "Large",
+                "Huge": "Huge",
+                "Anthro": "Anthromorphic",
+                "Missile": "Missile"
+            },
             "ChaseEnvironment": "Chase Environment",
             "Clearsight": "Clearsight",
             "ControlMode": "Control Mode",

--- a/public/locale/pt-BR/config.json
+++ b/public/locale/pt-BR/config.json
@@ -1407,6 +1407,17 @@
         "UseEdgeForInitiativeRoll": "Use a regra de vantagem blitz para iniciativa",
         "Value": "Valor",
         "Vehicle": {
+            "Category": "Categoria",
+            "Categories": {
+                "Micro": "Micro",
+                "Mini": "Mini",
+                "Small": "Pequeno",
+                "Medium": "Médio",
+                "Large": "Grande",
+                "Huge": "Enorme",
+                "Anthro": "Anthromórfico",
+                "Missile": "Míssil"
+            },
             "ChaseEnvironment": "Ambiente de Perseguição",
             "Clearsight": "Visão Clara",
             "ControlMode": "Modo de Controle",

--- a/src/module/actor/prep/VehiclePrep.ts
+++ b/src/module/actor/prep/VehiclePrep.ts
@@ -157,17 +157,13 @@ export class VehiclePrep {
     }
 
     static prepareConditionMonitor(system: Actor.SystemOfType<'vehicle'>) {
-        const { track, attributes, matrix, isDrone, modifiers } = system;
+        const { track, attributes, matrix, isDrone, modifiers, category } = system;
 
         const halfBody = Math.ceil(Helpers.calcTotal(attributes.body) / 2);
         // CRB pg 199 drone vs vehicle physical condition monitor rules
-        if (isDrone) {
-            track.physical.base = 6 + halfBody;
-            track.physical.max = track.physical.base + (Number(modifiers['physical_track']) || 0);
-        } else {
-            track.physical.base = 12 + halfBody;
-            track.physical.max =  track.physical.base + (Number(modifiers['physical_track']) || 0);
-        }
+        // Anthro vehicles have condition monitor as 8 + (body/2). R5 pg 145
+        track.physical.base = (isDrone ? (category === 'anthro' ? 8 : 6) : 12) + halfBody;
+        track.physical.max =  track.physical.base + modifiers['physical_track'];
         track.physical.label = SR5.damageTypes.physical;
 
         // Prepare internal matrix condition monitor values
@@ -190,10 +186,10 @@ export class VehiclePrep {
         // algorithm to determine speed, CRB pg 202 table.
         // Allow ActiveEffects to apply to movement directly.
         movement.walk.base = 5 * Math.pow(2, speedTotal - 1);
-        movement.walk.value = Helpers.calcTotal(movement.walk as ModifiableValueType, {min: 0});
+        movement.walk.value = Helpers.calcTotal(movement.walk, {min: 0});
 
         movement.run.base = 10 * Math.pow(2, speedTotal - 1);
-        movement.run.value = Helpers.calcTotal(movement.run as ModifiableValueType, {min: 0});
+        movement.run.value = Helpers.calcTotal(movement.run, {min: 0});
     }
 
     static prepareMeatspaceInit(system: Actor.SystemOfType<'vehicle'>) {
@@ -213,8 +209,8 @@ export class VehiclePrep {
     static prepareArmor(system: Actor.SystemOfType<'vehicle'>) {
         const { armor, modifiers } = system;
 
-        armor.mod = PartsList.AddUniquePart(armor.mod, 'SR5.Temporary', Number(armor['temp'] || 0));
-        armor.mod = PartsList.AddUniquePart(armor.mod, 'SR5.Bonus', Number(modifiers['armor'] || 0));
+        armor.mod = PartsList.AddUniquePart(armor.mod, 'SR5.Temporary', armor['temp']);
+        armor.mod = PartsList.AddUniquePart(armor.mod, 'SR5.Bonus', modifiers['armor']);
 
         Helpers.calcTotal(armor);
     }

--- a/src/module/apps/itemImport/parser/vehicle/VehicleParser.ts
+++ b/src/module/apps/itemImport/parser/vehicle/VehicleParser.ts
@@ -75,6 +75,9 @@ export class VehicleParser extends Parser<'vehicle'> {
         system.armor.base = Number(jsonData.armor._TEXT) || 0;
         system.isDrone = jsonData.category._TEXT.includes("Drone") || false;
 
+        if (system.isDrone)
+            system.category = jsonData.category._TEXT.replace("Drones: ", "").toLowerCase() as typeof system.category;
+
         const category = jsonData.category._TEXT.toLowerCase();
         system.vehicleType = /drone|hovercraft/.test(category) ? "exotic"    :
                              /boats|submarines/.test(category) ? "water"     :

--- a/src/module/config.ts
+++ b/src/module/config.ts
@@ -1101,6 +1101,16 @@ export const SR5 = {
             walker: 'SR5.Vehicle.Types.Walker',
             exotic: 'SR5.Vehicle.Types.Exotic',
         },
+        categories: {
+            micro: 'SR5.Vehicle.Categories.Micro',
+            mini: 'SR5.Vehicle.Categories.Mini',
+            small: 'SR5.Vehicle.Categories.Small',
+            medium: 'SR5.Vehicle.Categories.Medium',
+            large: 'SR5.Vehicle.Categories.Large',
+            huge: 'SR5.Vehicle.Categories.Huge',
+            anthro: 'SR5.Vehicle.Categories.Anthro',
+            missile: 'SR5.Vehicle.Categories.Missile',
+        },
         stats: {
             handling: 'SR5.Vehicle.Stats.Handling',
             off_road_handling: 'SR5.Vehicle.Stats.OffRoadHandling',

--- a/src/module/types/actor/Vehicle.ts
+++ b/src/module/types/actor/Vehicle.ts
@@ -42,6 +42,11 @@ const VehicleData = () => ({
         initial: "speed",
         choices: ["speed", "handling"],
     }),
+    category: new StringField({
+        required: true,
+        initial: "medium",
+        choices: ["micro", "mini", "small", "medium", "large", "huge", "anthro", "missile"],
+    }),
     isDrone: new BooleanField(),
     isOffRoad: new BooleanField(),
 

--- a/src/templates/actor/parts/vehicle/VehicleSecondStatsList.hbs
+++ b/src/templates/actor/parts/vehicle/VehicleSecondStatsList.hbs
@@ -39,6 +39,18 @@
     </div>
     {{/"systems/shadowrun5e/dist/templates/common/NameLineBlock.hbs"}}
 
+    {{#if system.isDrone}}
+    {{#> "systems/shadowrun5e/dist/templates/common/NameLineBlock.hbs" name=(localize "SR5.Vehicle.Category") }}
+    <div>
+        {{> "systems/shadowrun5e/dist/templates/common/Select.hbs"
+                    options=config.vehicle.categories
+                    value=system.category
+                    path="system.category"
+        }}
+    </div>
+    {{/"systems/shadowrun5e/dist/templates/common/NameLineBlock.hbs"}}
+    {{/if}}
+
     {{#> "systems/shadowrun5e/dist/templates/common/NameLineBlock.hbs" name=(localize "SR5.Vehicle.ChaseEnvironment") }}
     <div>
         {{> "systems/shadowrun5e/dist/templates/common/Select.hbs"


### PR DESCRIPTION
Adds Drones category so it can correct the Condition Monitor formula for Anthromorphic Drones from 6 + (Body / 2) to 8 + (Body / 2).

<img width="921" height="671" alt="image" src="https://github.com/user-attachments/assets/865da876-f312-4a56-8d8d-bda02c97955d" />
