### PR TITLE
[BUG] Switching initiative back from hot SIM to meat doesn't remove hot sim modifier

### DIFF
--- a/src/module/actor/sheets/SR5BaseActorSheet.ts
+++ b/src/module/actor/sheets/SR5BaseActorSheet.ts
@@ -401,7 +401,7 @@ export class SR5BaseActorSheet extends foundry.appv1.sheets.ActorSheet {
             // disable VR as well
             await this.actor.update({ system: {
                     initiative: { perception: newValue, },
-                    matrix: { vr: false }
+                    matrix: { vr: false, hot_sim: false }
                 }});
         } else if (newValue === 'hot_sim' || newValue === 'cold_sim') {
             // if we are hot sim or cold sim, we are in VR and using matrix init perception
@@ -410,7 +410,7 @@ export class SR5BaseActorSheet extends foundry.appv1.sheets.ActorSheet {
                     initiative: {
                         perception: 'matrix',
                     },
-                    matrix: { hot_sim: newValue === 'hot_sim', vr: true }
+                    matrix: { vr: true, hot_sim: newValue === 'hot_sim' }
                 },
             });
         }


### PR DESCRIPTION
Fixes #1607

hot_sim property didn't get hard set when moving into meatspace mode.