### PR TITLE
[BUG] Devices Can't Be Deactivated From Gear Tab

### DIFF
--- a/src/module/actor/SR5Actor.ts
+++ b/src/module/actor/SR5Actor.ts
@@ -2237,21 +2237,23 @@ export class SR5Actor<SubType extends Actor.ConfiguredSubType = Actor.Configured
      *
      * It's not necessary for the given item to be equipped.
      *
-     * @param unequipItem Input item that will be equipped while unequipping all others of the same type.
+     * @param toggledItem Input item that will be equipped while unequipping all others of the same type.
      */
-    async equipOnlyOneItemOfType(unequipItem: SR5Item) {
-        const sameTypeItems = this.items.filter(item => item.type === unequipItem.type);
-
-        // If the given item is the only of it's type, allow unequipping.
-        if (sameTypeItems.length === 1 && sameTypeItems[0].id === unequipItem.id) {
-            await unequipItem.update({ system: { technology: { equipped: !unequipItem.isEquipped() } } });
+    async equipOnlyOneItemOfType(toggledItem: SR5Item) {
+        // Allow unequipping of the only equipped item.
+        // This will leave all items as unequipped.
+        if (toggledItem.isEquipped()) {
+            await toggledItem.update({ system: { technology: { equipped: false } } });
             return
         }
+
+        // Unequipp all other items, while equipping the given item.
+        const sameTypeItems = this.items.filter(item => item.type === toggledItem.type);
 
         // For a set of items, assure only the selected is equipped.
         await this.updateEmbeddedDocuments('Item', sameTypeItems.map(item => ({
             _id: item.id,
-            system: { technology: { equipped: item.id === unequipItem.id } }
+            system: { technology: { equipped: item.id === toggledItem.id } }
         })));
     }
 


### PR DESCRIPTION
Fixes #1597

This keeps previous functionality of only allowing a single equipped device, while also allowing to unequipp it.