### PR TITLE
[Bug] Fix armor mod effects reverting after being toggled off

### DIFF
--- a/src/module/item/SR5Item.ts
+++ b/src/module/item/SR5Item.ts
@@ -787,7 +787,7 @@ export class SR5Item<SubType extends Item.ConfiguredSubType = Item.ConfiguredSub
             // will merge the _id into the existing effect and cause all kinds of issues.
             delete change._id;
 
-            mergeObject(effect, expandObject(change), { inplace: true });
+            effect.updateSource(expandObject(change));
             effect.render(false);
         }
 


### PR DESCRIPTION
Toggling off an Active Effect on a nested item silently reverted back to enabled shortly after being disabled.