### PR TITLE
[BUG] Biofeedback Resist action not getting translated

### DIFF
--- a/public/locale/de/config.json
+++ b/public/locale/de/config.json
@@ -943,7 +943,7 @@
         "Content": {
             "Actions": {
                 "Armor": "Panzerung",
-                "Biofeedback Resist": "Biofeedback widerstehen",
+                "BiofeedbackResist": "Biofeedback widerstehen",
                 "BruteForce": "Brute Force",
                 "ChangeConfiguration": "Konfiguration Ändern",
                 "ChangeIcon": "Icon Verändern",

--- a/public/locale/en/config.json
+++ b/public/locale/en/config.json
@@ -941,7 +941,7 @@
         "Content": {
             "Actions": {
                 "Armor": "Armor",
-                "Biofeedback Resist": "Biofeedback Resist",
+                "BiofeedbackResist": "Biofeedback Resist",
                 "BruteForce": "Brute Force",
                 "ChangeConfiguration": "Change Configuration",
                 "ChangeIcon": "Change Icon",


### PR DESCRIPTION
Fixes #2054

Issue was related to the translation label not being normalized corectly (PascalCase without any spaces).

Instead it was using `Biofeedback Resist`, but should have been `BiofeedbackResist`. This caused it to not be found and using the actual document name instead for any label referencing it.