### PR TITLE
[Chore] Recommend PDF Pager and verify support for Foundry VTT 14.367

### DIFF
--- a/system.json
+++ b/system.json
@@ -24,7 +24,7 @@
     "version": "0.37.0",
     "compatibility": {
         "minimum": "14.363",
-        "verified": "14.365",
+        "verified": "14.367",
         "maximum": "14"
     },
     "documentTypes": {
@@ -266,6 +266,14 @@
                 "compatibility": {
                     "minimum": "3.1.0",
                     "verified": "3.1.0"
+                }
+            },
+            {
+                "id": "pdf-pager",
+                "type": "module",
+                "compatibility": {
+                    "minimum": "14.1.0",
+                    "verified": "14.1.0"
                 }
             }
         ]


### PR DESCRIPTION
Adds PDF Pager 14.1.0 to the system’s recommended modules and marks Foundry VTT 14.367 as verified.