### PR TITLE
[Bug] Fix imported weapons not counting as normal weapons

### DIFF
--- a/src/module/apps/itemImport/parser/metatype/MetatypeParserBase.ts
+++ b/src/module/apps/itemImport/parser/metatype/MetatypeParserBase.ts
@@ -232,7 +232,7 @@ export abstract class MetatypeParserBase<TResult extends ('character' | 'spirit'
 
             system.action.attribute = 'agility';
             system.action.skill = isRanged ? 'exotic_ranged_weapon' : 'unarmed_combat';
-            system.action.damage = weaponParser.parseDamageData(damageText, apText);
+            system.action.damage = weaponParser.parseDamageData(damageText, apText, system.action.damage.normal_weapon);
 
             // --- Push Items ---
             // Loop through all parsed names and create a unique item for each one

--- a/src/module/apps/itemImport/parser/powers/CritterPowerParser.ts
+++ b/src/module/apps/itemImport/parser/powers/CritterPowerParser.ts
@@ -34,7 +34,7 @@ export class CritterPowerParser extends Parser<'critter_power'> {
             system.action.type = 'varies';
             system.action.attribute = 'agility';
             system.action.skill = naturalWeapon.useskill._TEXT.replace(/[\s-]/g, '_').toLowerCase();
-            system.action.damage = weaponParser.parseDamageData(naturalWeapon.damage._TEXT, naturalWeapon.ap._TEXT);
+            system.action.damage = weaponParser.parseDamageData(naturalWeapon.damage._TEXT, naturalWeapon.ap._TEXT, system.action.damage.normal_weapon);
 
             if (naturalWeapon.accuracy._TEXT.includes('Physical'))
                 system.action.limit.attribute = 'physical';

--- a/src/module/apps/itemImport/parser/weapon/WeaponParserBase.ts
+++ b/src/module/apps/itemImport/parser/weapon/WeaponParserBase.ts
@@ -94,7 +94,7 @@ export class WeaponParserBase extends Parser<'weapon'> {
         system.subcategory = category.toLowerCase();
 
         system.action.skill = this.getSkill(jsonData);
-        system.action.damage = this.parseDamageData(jsonData.damage._TEXT, jsonData.ap._TEXT);
+        system.action.damage = this.parseDamageData(jsonData.damage._TEXT, jsonData.ap._TEXT, system.action.damage.normal_weapon);
 
         if (jsonData.accuracy?._TEXT) {
             let accuracy: string = jsonData.accuracy._TEXT;
@@ -111,8 +111,8 @@ export class WeaponParserBase extends Parser<'weapon'> {
         return system;
     }
 
-    public parseDamageData(damageText: string | number, apText: string | number): DamageType {
-        const partialDamageData: Partial<DamageType> = {};
+    public parseDamageData(damageText: string | number, apText: string | number, normalWeapon = false): DamageType {
+        const partialDamageData: Partial<DamageType> = { normal_weapon: normalWeapon };
         const parsedDamageText = String(damageText).trim();
 
         const attributeDamage = /^(?:\((.+)\)|(.+?))([PSM])?(?:\(([a-zA-Z]+)\))?(?:\s+\(-?\d+\/m\))?$/i.exec(parsedDamageText);

--- a/src/unittests/sr5.WeaponParser.spec.ts
+++ b/src/unittests/sr5.WeaponParser.spec.ts
@@ -18,6 +18,12 @@ class TestCritterParser extends CritterParser {
     }
 }
 
+class TestWeaponParserBase extends WeaponParserBase {
+    public override getSystem(jsonData: any) {
+        return super.getSystem(jsonData);
+    }
+}
+
 class TestItemAmmoParser extends ItemAmmoParser {
     public override getSystem(jsonData: any) {
         return super.getSystem(jsonData);
@@ -201,6 +207,26 @@ export const weaponParserBaseTesting = (context: QuenchBatchContext) => {
         });
     })
 
+    describe("Item Import Weapon Values", () => {
+        const weaponParser = new TestWeaponParserBase();
+
+        it("Keeps imported weapons flagged as normal weapons", () => {
+            const system = weaponParser.getSystem(mockXmlData({
+                name: 'AK-98',
+                category: 'Assault Rifles',
+                type: 'Ranged',
+                damage: '10P',
+                ap: '-2',
+                accuracy: '5',
+                conceal: '6',
+            }));
+
+            assert.strictEqual(system.action.damage.base, 10);
+            assert.strictEqual(system.action.damage.ap.base, -2);
+            assert.strictEqual(system.action.damage.normal_weapon, true);
+        });
+    });
+
     describe("Actor Import Weapon Damage Values", () => {
         const actorWeaponParser = new ActorWeaponParser();
 
@@ -326,6 +352,7 @@ export const weaponParserBaseTesting = (context: QuenchBatchContext) => {
             assert.strictEqual(system.action.damage.base, 2);
             assert.strictEqual(system.action.damage.attribute, 'strength');
             assert.strictEqual(system.action.damage.ap.base, 1);
+            assert.strictEqual(system.action.damage.normal_weapon, true);
             assert.strictEqual(system.melee.reach, 1);
         });
     });


### PR DESCRIPTION
Weapons imported from Chummer data were flagged as not being normal weapons, so Immunity to Normal Weapons never applied against them.
