### PR TITLE
[Code] Update fvtt-types and adapt the system to the Foundry v14 API

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,7 @@
                 "events": "^3.3.0",
                 "fs-extra": "^11.4.0",
                 "fuse.js": "^7.5.0",
-                "fvtt-types": "github:BM123499/foundry-vtt-types#77e1f2bd5dfc91d333b308caf627e9a44765f8cc",
+                "fvtt-types": "github:BM123499/foundry-vtt-types#638dadc9a91195eda800e3de8f92d6f2cd465e2e",
                 "gulp": "^5.0.1",
                 "gulp-sass": "^6.0.1",
                 "jszip": "^3.10.1",
@@ -2617,6 +2617,17 @@
                 "node": ">= 0.6"
             }
         },
+        "node_modules/animejs": {
+            "version": "4.3.6",
+            "resolved": "https://registry.npmjs.org/animejs/-/animejs-4.3.6.tgz",
+            "integrity": "sha512-rzZ4bDc8JAtyx6hYwxj7s5M/yWfnM5qqY4hZDnhy1cWFvMb6H5/necHS2sbCY3WQTDbRLuZL10dPXSxSCFOr/w==",
+            "dev": true,
+            "license": "MIT",
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/juliangarnier"
+            }
+        },
         "node_modules/ansi-colors": {
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-1.1.0.tgz",
@@ -3940,8 +3951,9 @@
         },
         "node_modules/fvtt-types": {
             "name": "@league-of-foundry-developers/foundry-vtt-types",
-            "version": "14.363.0",
-            "resolved": "git+ssh://git@github.com/BM123499/foundry-vtt-types.git#77e1f2bd5dfc91d333b308caf627e9a44765f8cc",
+            "version": "14.366.0",
+            "resolved": "git+ssh://git@github.com/BM123499/foundry-vtt-types.git#638dadc9a91195eda800e3de8f92d6f2cd465e2e",
+            "integrity": "sha512-w/0F+42GpqJ7BJnIYhZhdF74LZiRQyqZswZh5tPd7dDbqJUyS0eBdP+87wNiqiSrjlqvy6/rBJuxACj7rNA0SQ==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -3957,13 +3969,13 @@
                 "@types/showdown": "~2.0.6",
                 "@types/simple-peer": "~9.11.1",
                 "@types/youtube": "~0.0.48",
+                "animejs": "4.3.6",
                 "codemirror": "^6.0.2",
                 "handlebars": "^4.7.9",
                 "handlebars-intl": "^1.1.2",
                 "jquery": "^3.7.1",
                 "mime-types": "^3.0.2",
                 "peggy": "^5.1.0",
-                "pixi-basis-ktx2": "^0.0.22",
                 "pixi.js": "github:foundry-vtt-types/pixi.js#main",
                 "prosemirror-collab": "^1.3.1",
                 "prosemirror-commands": "^1.7.1",
@@ -5524,21 +5536,6 @@
             },
             "funding": {
                 "url": "https://github.com/sponsors/jonschlinkert"
-            }
-        },
-        "node_modules/pixi-basis-ktx2": {
-            "version": "0.0.22",
-            "resolved": "https://registry.npmjs.org/pixi-basis-ktx2/-/pixi-basis-ktx2-0.0.22.tgz",
-            "integrity": "sha512-/1fa2YjjfYTG3AZlvnLu1B0uZPgXuFY2zijoy/VoUwGokHQ6HwLy0LtVVxFWK9Vwl5zGSRJnGpEV0/34ydKfog==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=18",
-                "npm": ">=8",
-                "yarn": ">=1.22"
-            },
-            "peerDependencies": {
-                "pixi.js": "^7.x.x"
             }
         },
         "node_modules/pixi.js": {

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
         "events": "^3.3.0",
         "fs-extra": "^11.4.0",
         "fuse.js": "^7.5.0",
-        "fvtt-types": "github:BM123499/foundry-vtt-types#77e1f2bd5dfc91d333b308caf627e9a44765f8cc",
+        "fvtt-types": "github:BM123499/foundry-vtt-types#638dadc9a91195eda800e3de8f92d6f2cd465e2e",
         "gulp": "^5.0.1",
         "gulp-sass": "^6.0.1",
         "jszip": "^3.10.1",

--- a/src/module/actor/SR5Actor.ts
+++ b/src/module/actor/SR5Actor.ts
@@ -136,9 +136,9 @@ export class SR5Actor<SubType extends Actor.ConfiguredSubType = Actor.Configured
     }
 
     /** Share skill pack reads across a creation. */
-    static override async createDocuments<Temporary extends boolean | undefined = undefined>(
+    static override async createDocuments(
         data: Actor.CreateInput[],
-        operation?: Actor.Database.CreateDocumentsOperation<Temporary>,
+        operation?: Actor.Database.CreateDocumentsOperation,
     ) {
         return PackItemFlow.withSkillPackCache(async () => await super.createDocuments(data, operation));
     }
@@ -225,10 +225,12 @@ export class SR5Actor<SubType extends Actor.ConfiguredSubType = Actor.Configured
      * @param {string} phase The application phase under which changes are to be applied.
      * @override
      */
-    override applyActiveEffects(...args) {
+    override applyActiveEffects(phase?: ActiveEffect.ChangePhase) {
+        phase ??= 'initial';
+
         // Errors during change application will stop that process and cause a broken sheet.
         try {
-            super.applyActiveEffects(...args);
+            super.applyActiveEffects(phase);
         } catch (error) {
             console.error(`Shadowrun5e | Some effect changes could not be applied and might cause issues. Check effects of actor (${this.name}) / id (${this.id})`);
             console.error(error);
@@ -1104,7 +1106,7 @@ export class SR5Actor<SubType extends Actor.ConfiguredSubType = Actor.Configured
      * @param options.byLabel true to search the skill by label as displayed on the sheet.
      * @param options.specialization true to configure the skill test to use a specialization.
      */
-    async startTeamworkTest(skillId: string, options?: ChatMessage.Database.CreateOperation<undefined>) {
+    async startTeamworkTest(skillId: string, options?: ChatMessage.Database.CreateOperation) {
         console.info(`Shadowrun5e | Starting teamwork test for ${skillId}`);
 
         // Prepare message content.

--- a/src/module/actor/flows/GmOnlyMessageContentFlow.ts
+++ b/src/module/actor/flows/GmOnlyMessageContentFlow.ts
@@ -54,12 +54,10 @@ export const GmOnlyMessageContentFlow = {
         // SuccessTest doesn't NEED an actor, if one is cast that way: show gm-only-content
         if (!actor || !game.user) {
             $(html).find('.gm-only-content').removeClass('gm-only-content');
-            // @ts-expect-error TODO: foundry-vtt-types v10
             ui.chat.scrollBottom();
         }
         else if (game.user.isGM || game.user.isTrusted || actor.isOwner) {
             $(html).find('.gm-only-content').removeClass('gm-only-content');
-            // @ts-expect-error TODO: foundry-vtt-types v10
             ui.chat.scrollBottom();
         }
     }

--- a/src/module/actor/sheets/SR5BaseActorSheet.ts
+++ b/src/module/actor/sheets/SR5BaseActorSheet.ts
@@ -2161,7 +2161,7 @@ export class SR5BaseActorSheet<T extends SR5ActorSheetData = SR5ActorSheetData> 
         return [
             SheetFlow._getSourceContextOption(),
             {
-                name: "SR5.ContextOptions.AddSkillEffect",
+                label: "SR5.ContextOptions.AddSkillEffect",
                 icon: "<i class='fas fa-file-circle-plus'></i>",
                 callback: async (target: HTMLElement) => {
                     const skillTarget = this._closestSkillTarget(target)!;
@@ -2171,14 +2171,14 @@ export class SR5BaseActorSheet<T extends SR5ActorSheetData = SR5ActorSheetData> 
                 }
             },
             {
-                name: "SR5.ContextOptions.EditSkill",
+                label: "SR5.ContextOptions.EditSkill",
                 icon: "<i class='fas fa-pen-to-square'></i>",
                 callback: async (target: HTMLElement) => {
                     await this._editSkill(target);
                 }
             },
             {
-                name: "SR5.ContextOptions.DeleteSkill",
+                label: "SR5.ContextOptions.DeleteSkill",
                 icon: "<i class='fas fa-trash'></i>",
                 callback: async (target: HTMLElement) => {
                     const userConsented = await Helpers.confirmDeletion();
@@ -2197,7 +2197,7 @@ export class SR5BaseActorSheet<T extends SR5ActorSheetData = SR5ActorSheetData> 
         return [
             SheetFlow._getSourceContextOption(),
             {
-                name: "SR5.ContextOptions.AddAttributeEffect",
+                label: "SR5.ContextOptions.AddAttributeEffect",
                 icon: "<i class='fas fa-file-circle-plus'></i>",
                 callback: async (target: HTMLElement) => {
                     const attributeId = (target.closest<HTMLElement>('[data-attribute-id]'))?.dataset.attributeId;
@@ -2237,7 +2237,7 @@ export class SR5BaseActorSheet<T extends SR5ActorSheetData = SR5ActorSheetData> 
             SheetFlow._getSourceContextOption(),
             {
                 // context menu to view items that aren't an embedded item of this actor
-                name: "SR5.ContextOptions.ViewItem",
+                label: "SR5.ContextOptions.ViewItem",
                 icon: "<i class='fas fa-eye'></i>",
                 condition: (target: HTMLElement) => {
                     const id = SheetFlow.closestItemId(target);
@@ -2256,7 +2256,7 @@ export class SR5BaseActorSheet<T extends SR5ActorSheetData = SR5ActorSheetData> 
                 }
             },
             {
-                name: "SR5.ContextOptions.EditItem",
+                label: "SR5.ContextOptions.EditItem",
                 icon: "<i class='fas fa-pen-to-square'></i>",
                 condition: (target: HTMLElement) => {
                     const id = SheetFlow.closestItemId(target);
@@ -2272,7 +2272,7 @@ export class SR5BaseActorSheet<T extends SR5ActorSheetData = SR5ActorSheetData> 
                 }
             },
             {
-                name: "SR5.ContextOptions.MoveItem",
+                label: "SR5.ContextOptions.MoveItem",
                 icon: "<i class='fas fa-arrow-right-arrow-left'></i>",
                 condition: (target: HTMLElement) => {
                     const id = SheetFlow.closestItemId(target);
@@ -2285,7 +2285,7 @@ export class SR5BaseActorSheet<T extends SR5ActorSheetData = SR5ActorSheetData> 
                 }
             },
             {
-                name: "SR5.ContextOptions.DeleteItem",
+                label: "SR5.ContextOptions.DeleteItem",
                 icon: "<i class='fas fa-trash'></i>",
                 condition: (target: HTMLElement) => {
                     const id = SheetFlow.closestItemId(target);
@@ -2310,7 +2310,7 @@ export class SR5BaseActorSheet<T extends SR5ActorSheetData = SR5ActorSheetData> 
         return [
             SheetFlow._getSourceContextOption(),
             {
-                name: "SR5.ContextOptions.EditEffect",
+                label: "SR5.ContextOptions.EditEffect",
                 icon: "<i class='fas fa-pen-to-square'></i>",
                 condition: (target: HTMLElement) => {
                     const id = SheetFlow.closestEffectId(target);
@@ -2335,7 +2335,7 @@ export class SR5BaseActorSheet<T extends SR5ActorSheetData = SR5ActorSheetData> 
                 }
             },
             {
-                name: "SR5.ContextOptions.DeleteEffect",
+                label: "SR5.ContextOptions.DeleteEffect",
                 icon: "<i class='fas fa-trash'></i>",
                 condition: (target: HTMLElement) => {
                     const id = SheetFlow.closestEffectId(target);

--- a/src/module/apps/actorImport/ActorSkillImport.ts
+++ b/src/module/apps/actorImport/ActorSkillImport.ts
@@ -30,7 +30,7 @@ type ImportedActorWithSkills = Actor.CreateData & {
     type: string;
     items: Item.CreateData[];
     system: {
-        skillset?: string;
+        skillset?: string | null;
     };
 };
 

--- a/src/module/apps/dialogs/PromptDialog.ts
+++ b/src/module/apps/dialogs/PromptDialog.ts
@@ -102,14 +102,14 @@ export class PromptDialog extends HandlebarsApplicationMixin(ApplicationV2)<Prom
     }
 
     override async close(options?: ApplicationV2.ClosingOptions): Promise<this> {
-        const closed = await super.close(options);
+        await super.close(options);
 
         if (this.canceled && !this._selectionSettled) {
             this._selectionSettled = true;
             this._selectionResolve(this.selection);
         }
 
-        return closed;
+        return this;
     }
 
     protected override async _prepareContext(

--- a/src/module/apps/dialogs/TestDialog.ts
+++ b/src/module/apps/dialogs/TestDialog.ts
@@ -25,7 +25,7 @@ export interface TestDialogListener {
 
 interface TestDialogContext extends HandlebarsApplicationMixin.RenderContext {
     test: any;
-    rollMode: ChatMessage.MessageMode;
+    rollMode: ChatMessage.Mode;
     rollModes: typeof CONFIG.ChatMessage.modes;
     config: typeof SR5;
     expandedPaths: string[];
@@ -126,14 +126,14 @@ export class TestDialog extends HandlebarsApplicationMixin(ApplicationV2)<TestDi
     }
 
     override async close(options?: ApplicationV2.ClosingOptions): Promise<this> {
-        const closed = await super.close(options);
+        await super.close(options);
 
         if (this.canceled && !this._selectionSettled) {
             this._selectionSettled = true;
             this._selectionResolve(this.selection);
         }
 
-        return closed;
+        return this;
     }
 
     static async #roll(this: TestDialog, event: Event) {

--- a/src/module/apps/itemImport/parser/Parser.ts
+++ b/src/module/apps/itemImport/parser/Parser.ts
@@ -6,6 +6,7 @@ import { IconAssign } from "../../iconAssigner/IconAssign";
 import { ImportHelper as IH } from "../helper/ImportHelper";
 import { TechnologyType } from "src/module/types/template/Technology";
 import { DataDefaults, SystemConstructorArgs, SystemEntityType } from "src/module/data/DataDefaults";
+import TypeDataModel = foundry.abstract.TypeDataModel;
 
 export type SystemType<T extends SystemEntityType> = ReturnType<Parser<T>["getBaseSystem"]>;
 
@@ -13,7 +14,7 @@ export abstract class Parser<SubType extends SystemEntityType> {
     protected abstract readonly parseType: SubType;
 
     private isActor(): this is Parser<SystemEntityType & Actor.SubType> {
-        return Object.keys(CONFIG.Actor.dataModels).includes(this.parseType);
+        return (Object.keys(CONFIG.Actor.dataModels) as string[]).includes(this.parseType);
     }
 
     protected getBonus(jsonData: ParseData) { return 'bonus' in jsonData ? jsonData.bonus : undefined; }
@@ -23,7 +24,8 @@ export abstract class Parser<SubType extends SystemEntityType> {
 
     private getSanitizedSystem(jsonData: ParseData) {
         const system = this.getSystem(jsonData);
-        const schema = CONFIG[this.isActor() ? "Actor" : "Item"].dataModels[this.parseType].schema;
+        const dataModels = CONFIG[this.isActor() ? "Actor" : "Item"].dataModels as Record<string, TypeDataModel.AnyConstructor>;
+        const schema = dataModels[this.parseType].schema;
         const correctionLogs = Sanitizer.sanitize(schema, system);
 
         if (correctionLogs) {

--- a/src/module/chat.ts
+++ b/src/module/chat.ts
@@ -1,5 +1,3 @@
-import { CORE_NAME } from './constants';
-
 /**
  * The legacy chat message approach of the system uses a generic chat message to display roll and item information.
  *
@@ -31,10 +29,9 @@ const createChatData = async (template: string, templateData) => {
         },
         item: templateData.item,
         content: html,
-        rollMode: game.settings.get(CORE_NAME, 'messageMode'),
     } as const;
 
-    ChatMessage.applyMode(chatData, chatData.rollMode);
+    ChatMessage.applyMode(chatData);
 
     return chatData;
 };

--- a/src/module/combat/SR5Combat.ts
+++ b/src/module/combat/SR5Combat.ts
@@ -24,7 +24,7 @@ type InitiativeSummaryRow = {
     document: TokenDocument | SR5Actor | null;
 
     // Dice So Nice animation support
-    roll: Roll;
+    roll: Roll.Implementation;
     combatant: SR5Combatant;
 };
 
@@ -128,7 +128,6 @@ export class SR5Combat extends Combat<"base"> {
 
     // Foundry's Combat interface defines nextCombatant as a getter, but SR5's initiative flow
     // doesn't have a single "next" combatant due to initiative passes.
-    // @ts-expect-error it will be correctly typed later
     override get nextCombatant(): undefined { return undefined; }
 
 
@@ -421,7 +420,7 @@ export class SR5Combat extends Combat<"base"> {
         const messageGroups = {
             public: [] as InitiativeSummaryRow[],
             gm: [] as InitiativeSummaryRow[],
-        } satisfies Partial<Record<ChatMessage.MessageMode, InitiativeSummaryRow[]>>;
+        } satisfies Partial<Record<ChatMessage.Mode, InitiativeSummaryRow[]>>;
 
         for (const id of combatantIds) {
             const combatant = this.combatants.get(id) as SR5Combatant | undefined;
@@ -596,7 +595,7 @@ export class SR5Combat extends Combat<"base"> {
      * @param messageOptions - Base configuration options for the created ChatMessage documents.
      */
     private async _createInitiativeMessages(
-        messageGroups: Partial<Record<ChatMessage.MessageMode, InitiativeSummaryRow[]>>,
+        messageGroups: Partial<Record<ChatMessage.Mode, InitiativeSummaryRow[]>>,
         messageOptions: ChatMessage.CreateData,
     ) {
         let hasPlayedSound = false;
@@ -645,7 +644,7 @@ export class SR5Combat extends Combat<"base"> {
     private _buildInitiativeRow(
         combatant: SR5Combatant,
         initiative: number,
-        roll: Roll,
+        roll: Roll.Implementation,
     ): InitiativeSummaryRow {
         const { actor, token, name } = combatant;
         const initiativeData = actor?.system?.initiative;
@@ -686,7 +685,7 @@ export class SR5Combat extends Combat<"base"> {
         };
     }
 
-    private _extractRollResults(roll: Roll): number[] {
+    private _extractRollResults(roll: Roll.Implementation): number[] {
         return roll.dice.flatMap(d => d.results.filter(r => r.active).map(r => r.result));
     }
 
@@ -699,7 +698,7 @@ export class SR5Combat extends Combat<"base"> {
      * @param base - The combatant's base initiative score.
      * @returns A formatted HTML string representing the tooltip.
      */
-    private _buildInitiativeTooltipHtml(actor: SR5Actor | null, roll: Roll, base: number): string {
+    private _buildInitiativeTooltipHtml(actor: SR5Actor | null, roll: Roll.Implementation, base: number): string {
         const wounds = actor?.system.wounds?.value;
         const penalty = Math.abs((this.pass - SR.combat.FIRST_PASS) * SR.combat.PASS_PENALTY);
 

--- a/src/module/combat/SR5Combatant.ts
+++ b/src/module/combat/SR5Combatant.ts
@@ -274,8 +274,8 @@ export class SR5Combatant extends Combatant<"base"> {
     }
 
     async playDSNInitiativeAnimation(
-        roll: Roll,
-        rollMode: ChatMessage.MessageMode,
+        roll: Roll.Implementation,
+        rollMode: ChatMessage.Mode,
         message: Pick<ChatMessage, 'id' | 'speaker' | 'whisper'>,
     ): Promise<boolean> {
         if (!game.modules.get('dice-so-nice')?.active || !game.dice3d) return false;

--- a/src/module/data/DataDefaults.ts
+++ b/src/module/data/DataDefaults.ts
@@ -163,9 +163,9 @@ export class DataDefaults {
         if (createData) {
             let correctionLogs: CorrectionLog | null;
             if (entity in CONFIG.Actor.dataModels)
-                correctionLogs = Sanitizer.sanitize(CONFIG.Actor.dataModels[entity].schema, createData);
+                correctionLogs = Sanitizer.sanitize(CONFIG.Actor.dataModels[entity as Actor.SubType].schema, createData);
             else if (entity in CONFIG.Item.dataModels)
-                correctionLogs = Sanitizer.sanitize(CONFIG.Item.dataModels[entity].schema, createData);
+                correctionLogs = Sanitizer.sanitize(CONFIG.Item.dataModels[entity as Item.SubType].schema, createData);
             else
                 throw new Error(`No schema found for entity type: ${entity}`);
 

--- a/src/module/effect/SR5ActiveEffect.ts
+++ b/src/module/effect/SR5ActiveEffect.ts
@@ -179,7 +179,7 @@ export class SR5ActiveEffect extends ActiveEffect {
      */
     static redirectToNearModifiableValue(model: DataModel.Any, change: ActiveEffect.ChangeData) {
         // Move key up one hierarchy and check indirect match
-        const nodes = change.key.split('.');
+        const nodes = (change.key ?? '').split('.');
         const property = nodes.pop() ?? '';
         const indirectKey = nodes.join('.');
 
@@ -204,7 +204,7 @@ export class SR5ActiveEffect extends ActiveEffect {
      * for users not aware of system internal around ModifiableValue.
      */
     static alterChange(model: DataModel.Any, change: ActiveEffect.ChangeData) {
-        if (!SR5ActiveEffect.getModifiableValue(model, change.key))
+        if (!SR5ActiveEffect.getModifiableValue(model, change.key ?? ''))
             SR5ActiveEffect.redirectToNearModifiableValue(model, change);
     }
 
@@ -334,7 +334,7 @@ export class SR5ActiveEffect extends ActiveEffect {
      * @param options Additional FoundryVTT options.
      */
     static override applyChange(
-        targetDoc: ActiveEffect.TargetDocument | DataModel.Any,
+        targetDoc: ActiveEffect.ChangeTarget | DataModel.Any,
         change: ActiveEffect.ChangeData,
         options: ActiveEffect.ApplyChangeOptions = {}
     ): Record<string, unknown> {
@@ -352,14 +352,14 @@ export class SR5ActiveEffect extends ActiveEffect {
         // TypedObjectField will otherwise create the missing property as a string,
         // which breaks data integrity and can result in errors like "undefined[object Object]".
         // For example, a change targeting "firstaid" instead of "first_aid" would trigger this case.
-        if (!foundry.utils.hasProperty(targetDoc, change.key))
+        if (!foundry.utils.hasProperty(targetDoc, change.key ?? ''))
             return {};
 
         // Resolve dynamic value references in change.
         const source = change.effect?.parent ?? targetDoc;
         SR5ActiveEffect.alterChange(targetDoc, change);
         SR5ActiveEffect.resolveDynamicChangeValue(source, change, targetDoc);
-        
+
         // Other cases should be directly applied to the data, without actor / schema handling.
         // This is used when applying effects to non-Actor objects, like tests. TokenDocument is
         // explicitly supported by Foundry v14's ActiveEffect.applyChange and must stay on the
@@ -375,7 +375,7 @@ export class SR5ActiveEffect extends ActiveEffect {
      * Handle application for none-Document objects. This is typically used for SuccessTest instances.
      */
     private static _applyToObject(object: any, change: ActiveEffect.ChangeData): Record<string, unknown> {
-        const target = foundry.utils.getProperty(object, change.key);
+        const target = foundry.utils.getProperty(object, change.key ?? '');
         const targetType = foundry.utils.getType(target);
 
         // Cast the effect change value to the correct type
@@ -447,7 +447,7 @@ export class SR5ActiveEffect extends ActiveEffect {
         // Roll.replaceFormulaData which substitutes strings unquoted and coerces booleans to 1/0.
         const value = DynamicValueEvaluator.evaluate(change.value, path => foundry.utils.getProperty(source, path));
 
-        const rendered = SR5ActiveEffect.renderValueForField(value, change.key, targetDoc);
+        const rendered = SR5ActiveEffect.renderValueForField(value, change.key ?? '', targetDoc);
         if (rendered !== undefined) change.value = rendered;
     }
 

--- a/src/module/effect/SR5ActiveEffectConfig.ts
+++ b/src/module/effect/SR5ActiveEffectConfig.ts
@@ -482,9 +482,7 @@ export class SR5ActiveEffectConfig extends foundry.applications.sheets.ActiveEff
         }, { once: true });
 
         this._valueEditor = editor;
-        // @ts-expect-error fvtt-types does not expose ApplicationV2 window.windowId yet.
         const windowId = this.window?.windowId;
-        // @ts-expect-error fvtt-types is missing the AppV2 render options overload here.
         void editor.render({
             force: true,
             window: windowId ? { windowId } : undefined,
@@ -537,7 +535,7 @@ export class SR5ActiveEffectConfig extends foundry.applications.sheets.ActiveEff
      */
     prepareChangeTypes() {
         return Object.entries(SR5ActiveEffect.CHANGE_TYPES)
-            .map(([type, { label }]) => ({ type, label: game.i18n.localize(label) }))
+            .map(([type, config]) => ({ type, label: game.i18n.localize(config!.label) }))
             .sort((a, b) => a.label.localeCompare(b.label, game.i18n.lang))
             .reduce((types, { type, label }) => {
                 types[type] = label;
@@ -548,7 +546,7 @@ export class SR5ActiveEffectConfig extends foundry.applications.sheets.ActiveEff
 
     prepareChangePriorityPlaceholders() {
         return Object.entries(SR5ActiveEffect.CHANGE_TYPES).reduce((placeholders, [type, data]) => {
-            placeholders[type] = String(data.defaultPriority ?? '');
+            placeholders[type] = String(data?.defaultPriority ?? '');
             return placeholders;
         }, {} as Record<string, string>);
     }

--- a/src/module/effect/flows/SuccessTestEffectsFlow.ts
+++ b/src/module/effect/flows/SuccessTestEffectsFlow.ts
@@ -48,7 +48,7 @@ export class SuccessTestEffectsFlow<T extends SuccessTest> {
                 changes.push(...targetChanges.map(change => {
                     const c = foundry.utils.deepClone<typeof changes[number]>(change as any);
                     // TODO: v15 - Foundry used to change data. references in changes to system. But tests use data.
-                    c.key = c.key.replace(/^system\./, 'data.');
+                    c.key = (c.key ?? '').replace(/^system\./, 'data.');
                     c.effect = effect;
                     return c;
                 }));

--- a/src/module/flows/ExtendedTestFlow.ts
+++ b/src/module/flows/ExtendedTestFlow.ts
@@ -466,7 +466,7 @@ export const ExtendedTestFlow = {
             glitch: test.glitched,
             criticalGlitch: test.criticalGlitched,
             poolUsed: test.pool.value,
-            timestamp: chatMessage.timestamp,
+            timestamp: chatMessage.timestamp ?? Date.now(),
             worldTime: game.time.worldTime,
             messageUuid,
             userId: senderId,

--- a/src/module/flows/SheetFlow.ts
+++ b/src/module/flows/SheetFlow.ts
@@ -113,7 +113,7 @@ export const SheetFlow = {
      */
     _getSourceContextOption() {
         return {
-            name: "SR5.ContextOptions.Source",
+            label: "SR5.ContextOptions.Source",
             icon: "<i class='fas fa-page'></i>",
             condition: (target: HTMLElement) => {
                 const source = this.closestSource(target);

--- a/src/module/helpers.ts
+++ b/src/module/helpers.ts
@@ -271,7 +271,9 @@ export class Helpers {
         const dest2D = canvas.grid.getCenterPoint({ x: tokenDest.x, y: tokenDest.y });
 
         // Use gridSpace to measure in grids instead of distance. This will give results parity to FoundryVTTs canvas ruler.
-        const distanceInGridUnits2D = canvas.grid.measurePath([origin2D, dest2D], {});
+        // all three declare the same signature, so measure through one of them no matter the scene's grid type.
+        const grid = canvas.grid as foundry.grid.SquareGrid;
+        const distanceInGridUnits2D = grid.measurePath([origin2D, dest2D]);
 
         // 3d coordinates and distance
         const originLOSHeight = Helpers.getTokenLOSHeight(tokenOrigin);
@@ -647,7 +649,7 @@ export class Helpers {
     ): { id: string, updateSkillData: Record<string, Record<string, SkillFieldType>> } | undefined {
         if (!skillDataPath || skillDataPath.length === 0) return undefined;
 
-        const id = randomID(idLength);
+        const id = foundry.utils.randomID(idLength);
         const updateSkillData = {
             [skillDataPath]: { [id]: skillField }
         };

--- a/src/module/hooks.ts
+++ b/src/module/hooks.ts
@@ -389,6 +389,7 @@ ___________________
         // Register document classes
         CONFIG.Actor.documentClass = SR5Actor;
         CONFIG.Item.documentClass = SR5Item;
+        // @ts-expect-error fvtt-types doesn't allow custom combatTracker yet
         CONFIG.ui.combat = SR5CombatTracker;
         CONFIG.Combat.documentClass = SR5Combat;
         CONFIG.Combatant.documentClass = SR5Combatant;
@@ -416,6 +417,7 @@ ___________________
 
         // Register general SR5Roll for JSON serialization support.
         CONFIG.Dice.terms[SR5Die.DENOMINATION] = SR5Die;
+        // @ts-expect-error // fvtt-types doesn't allow custom rolls yet
         CONFIG.Dice.rolls.push(SR5Roll);
         // @ts-expect-error // Register the SR5Roll dnd5e style.
         CONFIG.Roll = SR5Roll;
@@ -692,7 +694,7 @@ ___________________
      * @param data The update data given.
      * @param id The items id.
      */
-    static async updateIcConnectedToHostItem(item: SR5Item, data: Item.UpdateData, options: Item.Database.UpdateOptions, userId: string) {
+    static async updateIcConnectedToHostItem(item: SR5Item, data: Item.UpdateData, options: Item.Database.OnUpdateOptions, userId: string) {
         // Trigger type specific behaviour.
         if (item.isType('host'))
             await MatrixICFlow.handleUpdateItemHost(item);

--- a/src/module/item/SR5ItemSheet.ts
+++ b/src/module/item/SR5ItemSheet.ts
@@ -1034,7 +1034,7 @@ export class SR5ItemSheet<T extends SR5BaseItemSheetData = SR5ItemSheetData> ext
         return [
             SheetFlow._getSourceContextOption(),
             {
-                name: "SR5.ContextOptions.EditItem",
+                label: "SR5.ContextOptions.EditItem",
                 icon: "<i class='fas fa-pen-to-square'></i>",
                 callback: async (target: HTMLElement) => {
                     const id = SheetFlow.closestItemId(target);
@@ -1045,7 +1045,7 @@ export class SR5ItemSheet<T extends SR5BaseItemSheetData = SR5ItemSheetData> ext
                 }
             },
             {
-                name: "SR5.ContextOptions.DeleteItem",
+                label: "SR5.ContextOptions.DeleteItem",
                 icon: "<i class='fas fa-trash'></i>",
                 callback: async (target: HTMLElement) => {
                     const userConsented = await Helpers.confirmDeletion();
@@ -1064,7 +1064,7 @@ export class SR5ItemSheet<T extends SR5BaseItemSheetData = SR5ItemSheetData> ext
         return [
             SheetFlow._getSourceContextOption(),
             {
-                name: "SR5.ContextOptions.EditEffect",
+                label: "SR5.ContextOptions.EditEffect",
                 icon: "<i class='fas fa-pen-to-square'></i>",
                 callback: async (target: HTMLElement) => {
                     const id = SheetFlow.closestEffectId(target);
@@ -1081,7 +1081,7 @@ export class SR5ItemSheet<T extends SR5BaseItemSheetData = SR5ItemSheetData> ext
                 }
             },
             {
-                name: "SR5.ContextOptions.DeleteEffect",
+                label: "SR5.ContextOptions.DeleteEffect",
                 icon: "<i class='fas fa-trash'></i>",
                 condition: (target: HTMLElement) => {
                     const id = SheetFlow.closestEffectId(target);
@@ -1110,10 +1110,11 @@ export class SR5ItemSheet<T extends SR5BaseItemSheetData = SR5ItemSheetData> ext
         ...[event, form, submitData, options]: Parameters<ItemSheet['_processSubmitData']>
     ) {
         if (this.item._isNestedItem) {
-            await this.item.update(submitData as any, options as any);
-        } else {
-            await super._processSubmitData(event, form, submitData, options);
+            await this.item.update(submitData, options);
+            return undefined as any;
         }
+
+        return await super._processSubmitData(event, form, submitData, options);
     }
 
     static async #toggleActionSpecialization(this: SR5ItemSheet) {
@@ -1183,7 +1184,7 @@ export class SR5ItemSheet<T extends SR5BaseItemSheetData = SR5ItemSheetData> ext
      *                                    or null in case of failure or no action being taken
      * @protected
      */
-    protected async _onDropDocument(event, document) {
+    protected override async _onDropDocument(event, document): Promise<any> {
         switch (document.documentName) {
             case "ActiveEffect":
                 return (await this._onDropActiveEffect(event, document)) ?? null;
@@ -1209,7 +1210,7 @@ export class SR5ItemSheet<T extends SR5BaseItemSheetData = SR5ItemSheetData> ext
      *                                                 created, or otherwise a nullish value
      * @protected
      */
-    async _onDropActiveEffect(event, effect) {
+    override async _onDropActiveEffect(event, effect): Promise<any> {
         if (!this.item.isOwner) return null;
         const keepId = !this.item.effects.has(effect.id);
         const result = await SR5ActiveEffect.create(effect.toObject(), { parent: this.item, keepId });
@@ -1297,7 +1298,7 @@ export class SR5ItemSheet<T extends SR5BaseItemSheetData = SR5ItemSheetData> ext
      * @returns {Promise<void>}
      * @protected
      */
-    override _onDragStart(event: DragEvent) {
+    override async _onDragStart(event: DragEvent) {
         const target = event.currentTarget as HTMLElement;
         const targetElement = event.target as HTMLElement;
         if (targetElement?.dataset && 'link' in targetElement.dataset) return;

--- a/src/module/rolls/DiceSoNice.ts
+++ b/src/module/rolls/DiceSoNice.ts
@@ -49,7 +49,7 @@ export interface DiceSoNice {
      * @returns {Promise<boolean>} when resolved true if the animation was displayed, false if not.
      */
     showForRoll: (
-        roll: Roll,
+        roll: Roll.Implementation,
         user: User,
         synchronize: boolean,
         whisper: User[] | string[] | null,

--- a/src/module/template.ts
+++ b/src/module/template.ts
@@ -197,7 +197,8 @@ export default class Template extends foundry.canvas.placeables.MeasuredTemplate
         await this._finishPlacement(event);
         const destination = canvas.grid!.getSnappedPoint({x: this.document.x, y: this.document.y}, {mode: CONST.GRID_SNAPPING_MODES.CENTER});
         this.document.updateSource(destination);
-        this.#events.resolve(canvas.scene!.createEmbeddedDocuments("MeasuredTemplate", [this.document.toObject()]));
+        const cls = CONFIG.MeasuredTemplate.documentClass;
+        this.#events.resolve(cls.createDocuments([this.document.toObject()], { parent: canvas.scene }));
     }
 
     /* -------------------------------------------- */

--- a/src/module/tests/SuccessTest.ts
+++ b/src/module/tests/SuccessTest.ts
@@ -135,7 +135,7 @@ export interface SuccessTestData extends TestData {
 export interface TestOptions {
     showDialog: boolean
     showMessage: boolean
-    rollMode: ChatMessage.MessageMode
+    rollMode: ChatMessage.Mode
 }
 
 export interface SuccessTestMessageData {
@@ -290,10 +290,10 @@ export class SuccessTest<T extends SuccessTestData = SuccessTestData> {
      * The tests roll mode can be given by specific option, action setting or global configuration.
      * @param options The test options for the whole test
      */
-    _prepareRollMode(data: DeepPartial<T>, options: Partial<TestOptions>): ChatMessage.MessageMode {
+    _prepareRollMode(data: DeepPartial<T>, options: Partial<TestOptions>): ChatMessage.Mode {
         if (options.rollMode != null) return options.rollMode;
-        if (data?.action?.roll_mode) return data.action.roll_mode as ChatMessage.MessageMode;
-        else return game.settings.get(CORE_NAME, 'messageMode');
+        if (data?.action?.roll_mode) return data.action.roll_mode as ChatMessage.Mode;
+        else return game.settings.get(CORE_NAME, 'messageMode') as ChatMessage.Mode;
     }
 
     /**
@@ -1786,10 +1786,9 @@ export class SuccessTest<T extends SuccessTestData = SuccessTestData> {
         const content = await renderTemplate(this._chatMessageTemplate, templateData);
         // Prepare the actual message.
         const messageData = await this._prepareMessageData(content);
-        const options = { rollMode: this._rollMode };
 
-        //@ts-expect-error // TODO: foundry-vtt-types v10
-        const message = await ChatMessage.create(messageData, options);
+        // Let Foundry apply the message visibility mode, instead of applying whisper ids manually.
+        const message = await ChatMessage.create(messageData, { messageMode: this._rollMode });
 
         if (!message) return;
 
@@ -1946,8 +1945,8 @@ export class SuccessTest<T extends SuccessTestData = SuccessTestData> {
     /**
      * What ChatMessage rollMode is this test supposed to use?
      */
-    get _rollMode() {
-        return this.data.options?.rollMode ?? game.settings.get('core', 'messageMode');
+    get _rollMode(): ChatMessage.Mode {
+        return this.data.options?.rollMode ?? game.settings.get(CORE_NAME, 'messageMode') as ChatMessage.Mode;
     }
 
     /**
@@ -1988,9 +1987,6 @@ export class SuccessTest<T extends SuccessTestData = SuccessTestData> {
             },
             sound: CONFIG.sounds.dice,
         }
-
-        // Instead of manually applying whisper ids, let Foundry do it.
-        ChatMessage.applyMode(messageData, this._rollMode);
 
         return messageData;
     }

--- a/src/module/tests/SummonSpiritTest.ts
+++ b/src/module/tests/SummonSpiritTest.ts
@@ -160,7 +160,7 @@ export class SummonSpiritTest extends SuccessTest<SummonSpiritTestData> {
         // Lower from more to less explicit values being given.
         // Don't let force go below one.
         data.force = Math.max(data.force || summoning.system.spirit.force || 1, 1);
-        data.preparedSpiritUuid ||= summoning.system.spirit.uuid;
+        data.preparedSpiritUuid ||= summoning.system.spirit.uuid ?? '';
         data.optionalPowerCount = Math.floor(data.force / 3);
         data.reagent ||= 0;
     }

--- a/src/module/token/SR5CombatTracker.ts
+++ b/src/module/token/SR5CombatTracker.ts
@@ -69,7 +69,7 @@ export class SR5CombatTracker extends CombatTracker {
         const options = super._getEntryContextOptions();
 
         options.splice(1, 0, {
-            name: game.i18n.localize('SR5.COMBAT.SeizeInitiative'),
+            label: game.i18n.localize('SR5.COMBAT.SeizeInitiative'),
             icon: '<i class="fa-solid fa-angles-up"></i>',
             condition: li => {
                 const combatant = this._getCombatant(li);

--- a/src/module/types/fields/TagifyMultiField.ts
+++ b/src/module/types/fields/TagifyMultiField.ts
@@ -12,9 +12,6 @@ type TagifyElement<Choices extends StringField.Choices | undefined> = StringFiel
 type TagifyAssignment<Choices extends StringField.Choices | undefined> =
     // eslint-disable-next-line @typescript-eslint/no-deprecated
     ArrayField.AssignmentType<ArrayField.AssignmentElementType<TagifyElement<Choices>>, ArrayField.DefaultOptions>;
-/** The initialized type ArrayField derives for the given element field — re-stated so the `_toInput` override stays compatible. */
-type TagifyInitialized<Choices extends StringField.Choices | undefined> =
-    ArrayField.InitializedType<ArrayField.InitializedElementType<TagifyElement<Choices>>, ArrayField.DefaultOptions>;
 
 /**
  * Create an ArrayField that can be used with the Tagify system
@@ -63,7 +60,7 @@ export class TagifyMultiField<
      * - we need to use the hook in TagifyHooks to actually setup tagify as the sheet needs to be rendered first
      * - this is currently done in the _postRender function of SR5ActiveEffectConfig
      */
-    override _toInput(config: DataField.ToInputConfig<TagifyInitialized<Choices>> & { options?: TagifyList }) {
+    override _toInput(config: DataField.ToInputConfig<this> & { options?: TagifyList }) {
         const options = this._normalizeOptions(config.options);
         const selectedValues = Array.isArray(config.value) ? config.value : [];
 

--- a/src/module/types/fields/TagifySelectField.ts
+++ b/src/module/types/fields/TagifySelectField.ts
@@ -6,7 +6,6 @@ type TagifyList = TagifyOption[] | Record<string, string>;
 
 /** Default options with required: true, blank: true so callers don't have to pass them explicitly. */
 type TagifySelectDefaultOptions = Omit<StringField.DefaultOptions, 'required' | 'blank'> & { required: true; blank: true };
-type TagifyInitialized<Options extends StringField.Options<unknown>> = StringField.InitializedType<Options>;
 
 /**
  * A StringField that renders as a Tagify single-value select in edit mode.
@@ -37,7 +36,7 @@ export class TagifySelectField<
      * Override the _toInput function to return an input element setup for Tagify single-value select.
      * - TagifyHooks initializes the Tagify instance after render via the 'tagify-select' class
      */
-    override _toInput(config: DataField.ToInputConfig<TagifyInitialized<Options>> & { options?: TagifyList }): HTMLElement {
+    override _toInput(config: DataField.ToInputConfig<this> & { options?: TagifyList }): HTMLElement {
         const options = this._normalizeOptions(config.options);
 
         const input = document.createElement('input');

--- a/src/module/types/global.ts
+++ b/src/module/types/global.ts
@@ -110,6 +110,13 @@ declare module "fvtt-types/configuration" {
         name: "shadowrun5e";
     }
 
+    namespace CONFIG.ActiveEffect {
+        interface ExpiryEvents {
+            sr5MyActionStart: string;
+            sr5MyActionEnd: string;
+        }
+    }
+
     namespace CONFIG.Canvas {
         interface DetectionModes {
             astralPerception: AstralPerceptionDetectionMode;

--- a/src/module/types/item/Action.ts
+++ b/src/module/types/item/Action.ts
@@ -175,7 +175,15 @@ export const ActionRollData = (
     }),
     alt_mod: new NumberField({ required: true, nullable: false, integer: true, initial: 0 }),
     dice_pool_mod: ChangeList(),
-    roll_mode: new StringField({ blank: true, required: true }),
+    roll_mode: new StringField({
+        blank: true,
+        required: true,
+        choices: () => Object.entries(CONFIG.ChatMessage.modes)
+            .reduce<Record<string, string>>((choices, [mode, { label }]) => {
+                choices[mode] = label;
+                return choices;
+            }, {}),
+    }),
 });
 
 export const ActionPartData = (args: {

--- a/src/module/types/item/Action.ts
+++ b/src/module/types/item/Action.ts
@@ -175,11 +175,7 @@ export const ActionRollData = (
     }),
     alt_mod: new NumberField({ required: true, nullable: false, integer: true, initial: 0 }),
     dice_pool_mod: ChangeList(),
-    roll_mode: new StringField({
-        blank: true,
-        required: true,
-        choices: CONFIG.ChatMessage.modes,
-    }),
+    roll_mode: new StringField({ blank: true, required: true }),
 });
 
 export const ActionPartData = (args: {


### PR DESCRIPTION
Bumps `fvtt-types` from `77e1f2b` to `638dadc` and adapts the system to the API changes that pin surfaces. No user-facing behavior changes.

- **Chat message modes** — v14 renamed roll modes to message modes: `ChatMessage.MessageMode` → `ChatMessage.Mode`, and `SuccessTest` now passes `{ messageMode }` to `ChatMessage.create` instead of calling `applyMode` by hand, which also gets `ic` → `public` resolution for rolls. `chat.ts` relies on `applyMode` defaulting to the client's selected mode, and `Action.roll_mode` builds its `choices` lazily, so the field is no longer read before `CONFIG.ChatMessage.modes` is populated and modes registered by modules are included.
- **Context menus** — `ContextMenuEntry.name` became `label`.
- **MeasuredTemplate** — merged into Region in v14, so blast zones are created via `CONFIG.MeasuredTemplate.documentClass.createDocuments(..., { parent: canvas.scene })`, the same path `Scene#createEmbeddedDocuments` took internally.
- **Nullable fields** — fallbacks for `ActiveEffect.ChangeData#key`, `ChatMessage#timestamp`, `spirit.uuid` and the imported `skillset`.
- **Signatures** — `Roll` → `Roll.Implementation`, typed `applyActiveEffects(phase)`, the dropped `Temporary` generic, `OnUpdateOptions`, AppV2 override shapes, `foundry.utils.randomID`, `CONFIG.*.dataModels` indexing.
- **Suppressions** — four `@ts-expect-error` removed, two added for `CONFIG.ui.combat` and `CONFIG.Dice.rolls`, which systems still cannot override. Declares the system's active effect expiry events.

Follow-up: MeasuredTemplate is deprecated since v14 and removed in v16 — blast zones will need a real migration to Regions (`canvas.regions.placeRegion`) before then.

`npm run typecheck`, `npm run typecheck:tests` and `npm run lint:errors` all pass.
