### PR TITLE
[Bug] Fix defense handling for indirect combat spells

### DIFF
--- a/public/locale/en/config.json
+++ b/public/locale/en/config.json
@@ -3037,6 +3037,7 @@
             "RitualFailure": "The ritual was too strong for you",
             "RitualSuccess": "The ritual is sealed",
             "SoakBlockedByHardenedArmor": "Blocked By Hardened Armor",
+            "SpellResisted": "Spell Resisted",
             "SpiritSummonFailure": "Spirit fled!",
             "SpiritSummonSuccess": "Spirit summoned!",
             "SpriteCompilationFailure": "Sprite fled!",

--- a/src/module/config.ts
+++ b/src/module/config.ts
@@ -884,7 +884,10 @@ export const SR5 = {
      */
     opposedTests: {
         'spell': {
-            'combat': 'CombatSpellDefenseTest'
+            'combat': {
+                'direct': 'CombatSpellDefenseTest',
+                'indirect': 'PhysicalDefenseTest'
+            }
         }
     },
 
@@ -896,7 +899,10 @@ export const SR5 = {
      */
     opposedResistTests: {
         'spell': {
-            'combat': 'PhysicalResistTest'
+            'combat': {
+                'direct': '',
+                'indirect': 'PhysicalResistTest'
+            }
         }
     },
 

--- a/src/module/item/SR5Item.ts
+++ b/src/module/item/SR5Item.ts
@@ -1542,7 +1542,9 @@ export class SR5Item<SubType extends Item.ConfiguredSubType = Item.ConfiguredSub
         const result = await super._preCreate(...args);
         if (result === false) return false;
 
-        UpdateActionFlow.injectActionTestsIntoChangeData(this.type, data, data, this);
+        const actionChanges = {};
+        UpdateActionFlow.injectActionTestsIntoChangeData(this.type, data, actionChanges, this);
+        this.updateSource(actionChanges);
         return result;
     }
 

--- a/src/module/item/flows/UpdateActionFlow.ts
+++ b/src/module/item/flows/UpdateActionFlow.ts
@@ -1,3 +1,4 @@
+import { DeepPartial } from "fvtt-types/utils";
 import { SR5Item } from "../SR5Item";
 import { SR5 } from '../../config';
 import { PackItemFlow } from "./PackItemFlow";
@@ -99,7 +100,7 @@ export const UpdateActionFlow = {
     /**
      * See injectActionTestsIntoChangeData for documentation.
      */
-    injectWeaponTestIntoChangeData(type: string, changeData: Item.UpdateData & {system: Item.SystemOfType<'weapon'>}, applyData) {
+    injectWeaponTestIntoChangeData(type: string, changeData: DeepPartial<{system: Item.SystemOfType<'weapon'>}>, applyData) {
         // Abort when category isn't part of this change.
         if (changeData?.system?.category === undefined) return;
 
@@ -122,12 +123,16 @@ export const UpdateActionFlow = {
     /**
      * See injectActionTestsIntoChangeData for documentation.
      */
-    injectSpellTestIntoChangeData(type: string, changeData: Item.UpdateData & {system: Item.SystemOfType<'spell'>}, applyData) {
-        // Abort when category isn't part of this change.
-        if (changeData?.system?.category === undefined) return;
+    injectSpellTestIntoChangeData(type: string, changeData: DeepPartial<{system: Item.SystemOfType<'spell'>}>, applyData, spell?: SR5Item<'spell'>) {
+        // Reconfigure on category or direct/indirect changes, including partial item updates.
+        if (changeData?.system?.category === undefined && changeData?.system?.combat?.type === undefined) return;
+
+        const category = changeData.system?.category ?? spell?.system.category;
+        const combatType = changeData.system?.combat?.type ?? spell?.system.combat.type;
+        if (category === undefined) return;
 
         // Remove test when user selects empty category.
-        if (changeData.system.category === '') {
+        if (category === '') {
             foundry.utils.setProperty(applyData, 'system.action.test', '');
             return;
         } 
@@ -135,10 +140,17 @@ export const UpdateActionFlow = {
         // Based on category switch out active, opposed and resist test.
         const test = SR5.activeTests[type];
         const drainTest = SR5.followedTests[test] ?? '';
-        const opposedTest = SR5.opposedTests[type][changeData.system.category] || 'OpposedTest';
+        const opposedTest = 
+            (category === 'combat' 
+                ? SR5.opposedTests[type][category][combatType]
+                : SR5.opposedTests[type][category]
+            ) || 'OpposedTest';
 
-        const isDirectCombatSpell = changeData.system.category === 'combat' && changeData.system.combat?.type === 'direct';
-        const resistTest = isDirectCombatSpell ? '' : SR5.opposedResistTests[type][changeData.system.category] || '';
+        const resistTest = 
+            (category === 'combat'
+                ? SR5.opposedResistTests[type][category][combatType]
+                : SR5.opposedResistTests[type][category]
+            ) || '';
 
         foundry.utils.setProperty(applyData, 'system.action.test', test);
         foundry.utils.setProperty(applyData, 'system.action.opposed.test', opposedTest);
@@ -149,7 +161,7 @@ export const UpdateActionFlow = {
     /**
      * See injectActionTestsIntoChangeData for documentation.
      */
-    injectComplexFormTestIntoChangeData(type: string, changeData: Item.UpdateData & {system: Item.SystemOfType<'complex_form'>}, applyData) {
+    injectComplexFormTestIntoChangeData(type: string, changeData: DeepPartial<{system: Item.SystemOfType<'complex_form'>}>, applyData) {
         const test = SR5.activeTests[type];
 
         foundry.utils.setProperty(applyData, 'system.action.test', test);
@@ -159,7 +171,7 @@ export const UpdateActionFlow = {
     /**
      * See injectActionTestsIntoChangeData for documentation.
      */
-    injectCallInActionTestIntoChangeData(type: string, changeData: Item.UpdateData & {system: Item.SystemOfType<'call_in_action'>}, applyData) {
+    injectCallInActionTestIntoChangeData(type: string, changeData: DeepPartial<{system: Item.SystemOfType<'call_in_action'>}>, applyData) {
         if (changeData.system?.actor_type === undefined) return;
 
         if (changeData.system.actor_type === 'spirit') {

--- a/src/module/migrator/Migrator.ts
+++ b/src/module/migrator/Migrator.ts
@@ -20,6 +20,7 @@ import { Version0_35_1 } from './versions/Version0_35_1';
 import { Version0_35_2 } from './versions/Version0_35_2';
 import { Version0_36_0 } from './versions/Version0_36_0';
 import { Version0_37_0 } from './versions/Version0_37_0';
+import { Version0_37_4 } from './versions/Version0_37_4';
 import { VersionMigration, MigratableDocument, MigratableDocumentName, MigratableDocumentType } from "./VersionMigration";
 
 const { deepClone, setProperty } = foundry.utils;
@@ -68,6 +69,7 @@ export class Migrator {
         new Version0_35_2(),
         new Version0_36_0(),
         new Version0_37_0(),
+        new Version0_37_4(),
     ] as const;
 
     private static pendingMigrationCount = 0;

--- a/src/module/migrator/versions/Version0_37_4.ts
+++ b/src/module/migrator/versions/Version0_37_4.ts
@@ -1,0 +1,17 @@
+import { VersionMigration } from '../VersionMigration';
+
+/** Route existing indirect combat spells through physical defense. */
+export class Version0_37_4 extends VersionMigration {
+    readonly TargetVersion = '0.37.4';
+
+    override migrateItem(item: any): void {
+        if (item?.type !== 'spell'
+            || item.system?.category !== 'combat'
+            || item.system.combat?.type !== 'indirect') return;
+
+        const opposed = item.system.action?.opposed;
+        if (opposed?.test === 'CombatSpellDefenseTest') {
+            opposed.test = 'PhysicalDefenseTest';
+        }
+    }
+}

--- a/src/module/rules/ActiveDefenseRules.ts
+++ b/src/module/rules/ActiveDefenseRules.ts
@@ -10,10 +10,10 @@ export type ActiveDefenseData = Record<string, { label: Translation, value: numb
 export const ActiveDefenseRules = {
     /**
      * What active defenses are available for the given item? Based on SR5#190 'Active Defenses'
-     * @param weapon The equipped weapon used for the attack.
+     * @param item The equipped item used for the attack.
      * @param actor The actor performing the attack.
      */
-    availableActiveDefenses: (weapon: SR5Item<'weapon'>, actor: SR5Actor): ActiveDefenseData => {
+    availableActiveDefenses: (item: SR5Item, actor: SR5Actor): ActiveDefenseData => {
         // General purpose active defenses. ()
         const activeDefenses: ActiveDefenseData = {
             full_defense: {
@@ -23,7 +23,7 @@ export const ActiveDefenseRules = {
             },
         };
 
-        if (!weapon.isMeleeWeapon()) return activeDefenses;
+        if (!item.isMeleeWeapon()) return activeDefenses;
 
         // Melee weapon specific active defenses.
         activeDefenses['dodge'] = {
@@ -38,8 +38,8 @@ export const ActiveDefenseRules = {
         };
         activeDefenses['parry'] = {
             label: 'SR5.Parry',
-            weapon: weapon.name || '',
-            value: actor.findActiveSkill(weapon.system.action.skill)?.value,
+            weapon: item.name || '',
+            value: actor.findActiveSkill(item.system.action.skill)?.value,
             initMod: -5,
         };
 

--- a/src/module/statusEffects.ts
+++ b/src/module/statusEffects.ts
@@ -29,6 +29,15 @@ const SRStatus = [
                     ],
                 },
                 {
+                    // Running grants +2 physical defense.
+                    id: 'defense',
+                    applyTo: 'test_all',
+                    conditions: [
+                        { type: 'tests', mode: 'include', values: ['PhysicalDefenseTest'] },
+                        { type: 'categories', mode: 'include', values: ['defense'] },
+                    ],
+                },
+                {
                     // +4 raw on melee attacks = net +2 after the general -2 penalty.
                     id: 'melee',
                     applyTo: 'test_all',
@@ -41,12 +50,14 @@ const SRStatus = [
                     id: 'targetRanged',
                     applyTo: 'test_target',
                     conditions: [
-                        { type: 'tests', mode: 'include', values: ['RangedAttackTest', 'ThrownAttackTest'] },
+                        { type: 'tests', mode: 'include', values: ['RangedAttackTest', 'ThrownAttackTest', 'SpellCastingTest'] },
+                        { type: 'categories', mode: 'include', values: ['attack_ranged', 'attack_thrown'] },
                     ],
                 },
             ],
             changes: [
                 { key: "data.pool", type: "add", value: "-2", target: 'penalty' },
+                { key: "data.pool", type: "add", value: "2", target: 'defense' },
                 { key: "data.pool", type: "add", value: "4",  target: 'melee' },
                 { key: "data.pool", type: "add", value: "-2", target: 'targetRanged' },
             ],
@@ -68,6 +79,15 @@ const SRStatus = [
                     ],
                 },
                 {
+                    // Running grants +2 physical defense.
+                    id: 'defense',
+                    applyTo: 'test_all',
+                    conditions: [
+                        { type: 'tests', mode: 'include', values: ['PhysicalDefenseTest'] },
+                        { type: 'categories', mode: 'include', values: ['defense'] },
+                    ],
+                },
+                {
                     // +4 raw on melee attacks = net +2 after the general -2 penalty.
                     id: 'melee',
                     applyTo: 'test_all',
@@ -80,12 +100,14 @@ const SRStatus = [
                     id: 'targetRanged',
                     applyTo: 'test_target',
                     conditions: [
-                        { type: 'tests', mode: 'include', values: ['RangedAttackTest', 'ThrownAttackTest'] },
+                        { type: 'tests', mode: 'include', values: ['RangedAttackTest', 'ThrownAttackTest', 'SpellCastingTest'] },
+                        { type: 'categories', mode: 'include', values: ['attack_ranged', 'attack_thrown'] },
                     ],
                 },
             ],
             changes: [
                 { key: "data.pool", type: "add", value: "-2", target: 'penalty' },
+                { key: "data.pool", type: "add", value: "2", target: 'defense' },
                 { key: "data.pool", type: "add", value: "4",  target: 'melee' },
                 { key: "data.pool", type: "add", value: "-4", target: 'targetRanged' },
             ],

--- a/src/module/tests/CombatSpellDefenseTest.ts
+++ b/src/module/tests/CombatSpellDefenseTest.ts
@@ -8,6 +8,7 @@ import {TestCreator} from "./TestCreator";
 import ModifierTypes = Shadowrun.ModifierTypes;
 import { ActionRollType, MinimalActionType } from "../types/item/Action";
 import { DeepPartial } from "fvtt-types/utils";
+import { Translation } from "../utils/strings";
 
 export interface CombatSpellDefenseTestData extends DefenseTestData {
     against: SpellCastingTestData
@@ -15,6 +16,10 @@ export interface CombatSpellDefenseTestData extends DefenseTestData {
 
 export class CombatSpellDefenseTest extends DefenseTest<CombatSpellDefenseTestData> {
     declare against: SpellCastingTest;
+
+    override get successLabel(): Translation {
+        return 'SR5.TestResults.SpellResisted';
+    }
 
     /**
      * A combat spell defense test changes it's behaviour based on the spell it's defending against.

--- a/src/module/tests/PhysicalDefenseTest.ts
+++ b/src/module/tests/PhysicalDefenseTest.ts
@@ -5,13 +5,13 @@ import {MeleeAttackData} from "./MeleeAttackTest";
 import {TestCreator} from "./TestCreator";
 import {DefenseTest, DefenseTestData} from "./DefenseTest";
 import ModifierTypes = Shadowrun.ModifierTypes;
-import { FLAGS, SYSTEM_NAME } from "../constants";
 import { Translation } from '../utils/strings';
 import { ActiveDefenseRules } from "../rules/ActiveDefenseRules";
 import { DeepPartial } from "fvtt-types/utils";
 import { TestOptions } from "./SuccessTest";
 import { MinimalActionType } from "../types/item/Action";
-import { SR5Item } from "../item/SR5Item";
+import { CombatSpellRules } from "../rules/CombatSpellRules";
+import { SpellCastingTestData } from "./SpellCastingTest";
 
 export interface PhysicalDefenseTestData extends DefenseTestData {
     // Dialog input for cover modifier
@@ -44,6 +44,15 @@ export class PhysicalDefenseTest<T extends PhysicalDefenseTestData = PhysicalDef
         return 'systems/shadowrun5e/dist/templates/apps/dialogs/physical-defense-test-dialog.hbs';
     }
 
+    override prepareBaseValues() {
+        super.prepareBaseValues();
+        const spell = this.against.item?.asType('spell');
+        if (spell?.system.category === 'combat' && spell.system.combat.type === 'indirect') {
+            const casting = this.data.against as SpellCastingTestData;
+            this.data.incomingDamage = CombatSpellRules.calculateIndirectDamage(this.data.incomingDamage, casting.force);
+        }
+    }
+
     static override _getDefaultTestAction(): DeepPartial<MinimalActionType> {
         return { attribute: 'reaction', attribute2: 'intuition' };
     }
@@ -72,7 +81,7 @@ export class PhysicalDefenseTest<T extends PhysicalDefenseTestData = PhysicalDef
         const weapon = this.against.item;
         if (weapon === undefined) return;
         
-        this.data.activeDefenses = ActiveDefenseRules.availableActiveDefenses(weapon as SR5Item<'weapon'>, actor);
+        this.data.activeDefenses = ActiveDefenseRules.availableActiveDefenses(weapon, actor);
 
         // Filter available active defenses by available ini score.
         this._filterActiveDefenses();

--- a/src/module/tests/SpellCastingTest.ts
+++ b/src/module/tests/SpellCastingTest.ts
@@ -65,7 +65,12 @@ export class SpellCastingTest extends SuccessTest<SpellCastingTestData> {
         if (!spell) return [];
 
         switch (spell.system.category) {
-            case 'combat': return ['spell_combat'];
+            case 'combat':
+                if (spell.system.combat.type === 'indirect' && spell.system.range === 'los')
+                    return ['spell_combat', 'attack', 'attack_ranged'];
+
+                return ['spell_combat'];
+
             case 'detection': return ['spell_detection'];
             case 'health': return ['spell_healing'];
             case 'illusion': return ['spell_illusion'];

--- a/src/unittests/sr5.SR5Item.spec.ts
+++ b/src/unittests/sr5.SR5Item.spec.ts
@@ -66,7 +66,7 @@ export const shadowrunSR5Item = (context: QuenchBatchContext) => {
                 await item.update({ system: { category: 'combat', combat: { type: 'indirect' } } });
                 assert.equal(item.system.action.test, 'SpellCastingTest');
                 assert.equal(item.system.action.followed.test, 'DrainTest');
-                assert.equal(item.system.action.opposed.test, 'CombatSpellDefenseTest');
+                assert.equal(item.system.action.opposed.test, 'PhysicalDefenseTest');
                 assert.equal(item.system.action.opposed.resist.test, 'PhysicalResistTest');
             });
             it('Correctly add default tests to melee weapons', async () => {


### PR DESCRIPTION
Route indirect combat spells through physical defense, apply movement modifiers, and migrate existing spells. Keep direct spell resistance separate.