### PR TITLE
[Bug, Layout] Use numeric fields for large item Matrix monitors

### DIFF
--- a/src/css/horixontal-cells.scss
+++ b/src/css/horixontal-cells.scss
@@ -63,6 +63,17 @@
             }
         }
 
+        .numeric-condition-monitor {
+            display: flex;
+            align-items: center;
+            gap: 0.25rem;
+
+            input {
+                width: 5rem;
+                text-align: center;
+            }
+        }
+
         .cell-container {
             display: flex;
             flex-flow: row wrap;

--- a/src/module/actor/sheets/SR5BaseActorSheet.ts
+++ b/src/module/actor/sheets/SR5BaseActorSheet.ts
@@ -639,6 +639,7 @@ export class SR5BaseActorSheet<T extends SR5ActorSheetData = SR5ActorSheetData> 
 
         html.find('input[data-system-action="changeSkillRating"]').on('change', this._onChangeSkillRating.bind(this));
         html.find('input[data-system-action="changeItemQty"]').on('change', this._onListItemChangeQuantity.bind(this));
+        html.find('input[data-system-action="changeItemMatrixDamage"]').on('change', event => SheetFlow.changeItemMatrixDamage(event));
     }
 
     private async _onSourceDrop(event?: DragEvent) {

--- a/src/module/flows/SheetFlow.ts
+++ b/src/module/flows/SheetFlow.ts
@@ -3,6 +3,20 @@ import { LinksHelpers } from '@/module/utils/links';
 import { SR5Item } from '@/module/item/SR5Item';
 
 export const SheetFlow = {
+    async changeItemMatrixDamage(event: Pick<Event, 'currentTarget'>, item?: SR5Item) {
+        const input = event.currentTarget;
+        if (!(input instanceof HTMLInputElement) || !Number.isFinite(input.valueAsNumber)) return;
+
+        if (!item) {
+            const uuid = input.closest<HTMLElement>('[data-uuid]')?.dataset.uuid;
+            const document = uuid ? await fromUuid(uuid) : undefined;
+            if (!(document instanceof SR5Item)) return;
+            item = document;
+        }
+
+        await item.setMatrixDamage(Math.max(0, Math.trunc(input.valueAsNumber)));
+    },
+
     _getCreateItemText(type: string): string {
         switch (type) {
             case 'lifestyle':

--- a/src/module/item/SR5ItemSheet.ts
+++ b/src/module/item/SR5ItemSheet.ts
@@ -543,6 +543,7 @@ export class SR5ItemSheet<T extends SR5BaseItemSheetData = SR5ItemSheetData> ext
 
         // Inline change handlers for nested list items (qty inputs in edit mode)
         html.find('input[data-system-action="changeItemQty"]').on('change', this._onListItemChangeQuantity.bind(this));
+        html.find('input[data-system-action="changeItemMatrixDamage"]').on('change', event => SheetFlow.changeItemMatrixDamage(event, this.item));
 
         // Marks handling
         html.find('.marks-qty').on('change', this._onMarksQuantityChange.bind(this));

--- a/src/templates/v2/common/horizontal-cells.hbs
+++ b/src/templates/v2/common/horizontal-cells.hbs
@@ -41,6 +41,14 @@
             <i class="fas fa-ban"></i>
         </a>
     </div>
+    {{#if (and compactLargeMonitor (gt max 20))}}
+    <div class="numeric-condition-monitor">
+        <input type="number" class="short" value="{{value}}" min="0" max="{{max}}" step="1"
+               data-system-action="changeItemMatrixDamage" aria-label="{{localize tooltip}}">
+        <span>/</span>
+        <input type="number" class="short" value="{{max}}" readonly aria-label="{{localize 'SR5.ConditionMonitor'}}">
+    </div>
+    {{else}}
     <div class="cell-container">
         {{#for 1 (sum max 1)}}
             <div class="cell {{#iflte this ../value}}filled{{/iflte}}"
@@ -58,6 +66,7 @@
             </div>
         {{/for}}
     </div>
+    {{/if}}
 </div>
 {{/if}}
 {{#ife track.max 0}}

--- a/src/templates/v2/item/header.hbs
+++ b/src/templates/v2/item/header.hbs
@@ -46,6 +46,7 @@
                                     value=system.technology.condition_monitor.value
                                     max=system.technology.condition_monitor.max
                                     id='matrix'
+                                    compactLargeMonitor=true
                                     disabled=system.technology.condition_monitor.disabled }}
                             </div>
                         </div>

--- a/src/templates/v2/item/header/skill.hbs
+++ b/src/templates/v2/item/header/skill.hbs
@@ -68,6 +68,7 @@
                                     value=system.technology.condition_monitor.value
                                     max=system.technology.condition_monitor.max
                                     id='matrix'
+                                    compactLargeMonitor=true
                                     disabled=system.technology.condition_monitor.disabled }}
                             </div>
                         </div>

--- a/src/templates/v2/list-items/matrix-condition-monitor.hbs
+++ b/src/templates/v2/list-items/matrix-condition-monitor.hbs
@@ -7,6 +7,7 @@
             value=item.system.technology.condition_monitor.value
             max=item.system.technology.condition_monitor.max
             id='matrix'
+            compactLargeMonitor=true
             disabled=item.system.technology.condition_monitor.disabled }}
     </div>
 {{/if}}


### PR DESCRIPTION
Replace monitors above 20 boxes with editable damage and read-only maximum fields on item sheets and inventory rows.

Fixes #2066 

<img width="766" height="211" alt="image" src="https://github.com/user-attachments/assets/393fc9f6-c691-4b26-bcc5-5136289e3c3a" />
