### PR TITLE
[Bug] Fix SR5 initiative-pass padding appearing in Carousel Combat Tracker

### DIFF
--- a/src/module/combat/SR5Combat.ts
+++ b/src/module/combat/SR5Combat.ts
@@ -285,7 +285,7 @@ export class SR5Combat extends Combat<"base"> {
         // Add padding combatants for the new pass.
         // These will be sorted to the end of the initiative order and can be used to track pass
         // changes in the UI and prevent issues with combatants being added mid-pass.
-        const padData = this.turns.filter(c => !c.system.pad).map(() => ({ system: { pad: true } }));
+        const padData = this.turns.filter(c => !c.system.pad).map(() => ({ hidden: true, system: { pad: true } }));
         await this.createEmbeddedDocuments("Combatant", padData);
 
         updateData.combatants = this.combatants.map((c) => c.initPassUpdateData());

--- a/src/module/hooks.ts
+++ b/src/module/hooks.ts
@@ -91,6 +91,7 @@ import { JournalEnrichers } from './journal/enricher';
 import { DataStorage } from './data/DataStorage';
 import { IconAssign } from './apps/iconAssigner/IconAssign';
 import { RoutingLibIntegration } from './integrations/routingLibIntegration';
+import { CombatTrackerDockIntegration } from './integrations/combatTrackerDockIntegration';
 import { initDiceSoNice } from './rolls/DiceSoNice';
 import { SR5TokenDocument } from './token/SR5TokenDocument';
 import { SR5TokenRuler } from './token/SR5TokenRuler';
@@ -202,6 +203,10 @@ export class HooksManager {
                 DevHooks.registerHooks();
             });
         }
+
+        // Custom Module Integrations
+        // See src/module/integartions for more information.
+        CombatTrackerDockIntegration.registerHooks();
     }
 
     static init() {

--- a/src/module/integrations/combatTrackerDockIntegration.ts
+++ b/src/module/integrations/combatTrackerDockIntegration.ts
@@ -1,9 +1,46 @@
+import type { SR5Combat } from '../combat/SR5Combat';
+
 export interface CombatTrackerDockConfig {
     CombatantPortrait: new (combatant: Combatant.Implementation) => {
         combatant: Combatant.Implementation;
         // oxlint-disable-next-line typescript/method-signature-style
         getData(): Promise<unknown>;
     };
+    CombatDock: new (combat?: SR5Combat) => {
+        combat: SR5Combat;
+        element: HTMLElement | null;
+        // oxlint-disable-next-line typescript/method-signature-style
+        _onRender(context: unknown, options: unknown): void;
+        // oxlint-disable-next-line typescript/method-signature-style
+        updateStartEndButtons(): void;
+    };
+}
+
+/** SR5 labels for Carousel's dock buttons: a Foundry turn is an SR5 action phase, a Foundry round an SR5 combat turn. */
+const DOCK_BUTTON_LABELS = {
+    'previous-turn': 'SR5.COMBAT.PreviousPhase',
+    'next-turn': 'SR5.COMBAT.NextPhase',
+    'previous-round': 'SR5.COMBAT.PreviousTurn',
+    'next-round': 'SR5.COMBAT.NextTurn',
+} as const;
+
+const PASS_BUTTON_ACTIONS = ['sr5-previous-pass', 'sr5-next-pass'] as const;
+
+/** Build a dock control button that runs an SR5 initiative pass method. */
+function createPassButton(
+    action: typeof PASS_BUTTON_ACTIONS[number],
+    icon: string,
+    label: string,
+    onClick: () => Promise<unknown>
+): HTMLButtonElement {
+    const button = document.createElement('button');
+    button.type = 'button';
+    button.className = `icon ui-control fa-solid ${icon}`;
+    button.dataset.action = action;
+    button.dataset.tooltip = label;
+    button.setAttribute('aria-label', game.i18n.localize(label));
+    button.addEventListener('click', () => { void onClick(); });
+    return button;
 }
 
 /**
@@ -12,11 +49,15 @@ export interface CombatTrackerDockConfig {
  * SR5 uses `system.pad` combatants as internal initiative-pass markers. They are
  * not turns and must not be presented as portraits. Carousel deliberately renders
  * hidden combatants for GMs, so its portrait class needs to handle SR5 pads directly.
+ *
+ * Carousel's dock controls use Foundry's turn/round terms and have no initiative pass
+ * controls, so its dock class relabels them with SR5 terms and adds Previous/Next Pass
+ * buttons once combat has started.
  */
 export class CombatTrackerDockIntegration {
     /**
      * Carousel calls this hook as it publishes its extensibility configuration during `init`.
-     * Registering before `init` allows SR5 to replace only the portrait class without mutating
+     * Registering before `init` allows SR5 to replace its portrait and dock classes without mutating
      * Carousel's combatant ordering or its source files.
      */
     static registerHooks(): void {
@@ -27,6 +68,49 @@ export class CombatTrackerDockIntegration {
                 override async getData(): Promise<unknown> {
                     if (this.combatant.system?.pad === true) return null;
                     return super.getData();
+                }
+            };
+
+            const BaseCombatDock = config.CombatDock;
+
+            config.CombatDock = class extends BaseCombatDock {
+                // Carousel derives its template path from APP_ID, which an anonymous subclass cannot infer.
+                static get APP_ID(): string {
+                    return 'combat-dock';
+                }
+
+                // The dock re-renders its whole template, so the buttons are re-applied after every render.
+                override _onRender(context: unknown, options: unknown): void {
+                    super._onRender(context, options);
+                    if (!this.element) return;
+
+                    for (const [action, label] of Object.entries(DOCK_BUTTON_LABELS)) {
+                        const button = this.element.querySelector<HTMLElement>(`[data-action="${action}"]`);
+                        if (!button) continue;
+                        button.dataset.tooltip = label;
+                        button.setAttribute('aria-label', game.i18n.localize(label));
+                    }
+
+                    // Carousel binds its button listeners during super._onRender, so these only get their own.
+                    this.element.querySelector('[data-action="previous-turn"]')?.after(
+                        createPassButton('sr5-previous-pass', 'fa-backward-step', 'SR5.COMBAT.PreviousPass', async () => this.combat.previousPass())
+                    );
+                    this.element.querySelector('[data-action="next-turn"]')?.after(
+                        createPassButton('sr5-next-pass', 'fa-forward-step', 'SR5.COMBAT.NextPass', async () => this.combat.nextPass())
+                    );
+
+                    this.updateStartEndButtons();
+                }
+
+                // Passes only exist in a started combat; SR5Combat.nextPass would otherwise create pads.
+                override updateStartEndButtons(): void {
+                    super.updateStartEndButtons();
+                    if (!this.element) return;
+
+                    for (const action of PASS_BUTTON_ACTIONS) {
+                        const button = this.element.querySelector<HTMLElement>(`[data-action="${action}"]`);
+                        if (button) button.style.display = this.combat.started ? '' : 'none';
+                    }
                 }
             };
         });

--- a/src/module/integrations/combatTrackerDockIntegration.ts
+++ b/src/module/integrations/combatTrackerDockIntegration.ts
@@ -1,0 +1,34 @@
+export interface CombatTrackerDockConfig {
+    CombatantPortrait: new (combatant: Combatant.Implementation) => {
+        combatant: Combatant.Implementation;
+        // oxlint-disable-next-line typescript/method-signature-style
+        getData(): Promise<unknown>;
+    };
+}
+
+/**
+ * Compatibility integration for Carousel Combat Tracker (`combat-tracker-dock`).
+ *
+ * SR5 uses `system.pad` combatants as internal initiative-pass markers. They are
+ * not turns and must not be presented as portraits. Carousel deliberately renders
+ * hidden combatants for GMs, so its portrait class needs to handle SR5 pads directly.
+ */
+export class CombatTrackerDockIntegration {
+    /**
+     * Carousel calls this hook as it publishes its extensibility configuration during `init`.
+     * Registering before `init` allows SR5 to replace only the portrait class without mutating
+     * Carousel's combatant ordering or its source files.
+     */
+    static registerHooks(): void {
+        Hooks.once('combat-tracker-dock-init', (config: CombatTrackerDockConfig) => {
+            const BaseCombatantPortrait = config.CombatantPortrait;
+
+            config.CombatantPortrait = class extends BaseCombatantPortrait {
+                override async getData(): Promise<unknown> {
+                    if (this.combatant.system?.pad === true) return null;
+                    return super.getData();
+                }
+            };
+        });
+    }
+}

--- a/src/module/token/SR5CombatTracker.ts
+++ b/src/module/token/SR5CombatTracker.ts
@@ -2,6 +2,7 @@ import { ValueOf } from 'fvtt-types/utils';
 import { SR5Combat } from '../combat/SR5Combat';
 import { InitiativeModeOptions, SR5Combatant } from '../combat/SR5Combatant';
 import CombatTracker = foundry.applications.sidebar.tabs.CombatTracker;
+import ContextMenu = foundry.applications.ux.ContextMenu;
 
 type InitiativeModeOption = {
     value: InitiativeModeOptions;
@@ -69,9 +70,9 @@ export class SR5CombatTracker extends CombatTracker {
         const options = super._getEntryContextOptions();
 
         options.splice(1, 0, {
-            name: game.i18n.localize('SR5.COMBAT.SeizeInitiative'),
-            icon: '<i class="fa-solid fa-angles-up"></i>',
-            condition: li => {
+            label: 'SR5.COMBAT.SeizeInitiative',
+            icon: 'fa-solid fa-angles-up',
+            visible: (li: HTMLElement) => {
                 const combatant = this._getCombatant(li);
                 if (!combatant) return false;
 
@@ -79,10 +80,10 @@ export class SR5CombatTracker extends CombatTracker {
                 // eslint-disable-next-line eqeqeq
                 return combatant.isOwner && edge != null && combatant.initiative != null;
             },
-            callback: li => {
-                void this._onSeizeInitiative(li);
+            onClick: (event: PointerEvent, li: HTMLElement) => {
+                void this._getCombatant(li)?.toggleSeizeInitiative();
             }
-        });
+        } as unknown as ContextMenu.Entry<HTMLElement>);
 
         return options;
     }
@@ -214,10 +215,6 @@ export class SR5CombatTracker extends CombatTracker {
         await combatant.update({ system: { acted: !combatant.system.acted } });
     }
 
-    private async _onSeizeInitiative(li: HTMLElement): Promise<void> {
-        await this._getCombatant(li)?.toggleSeizeInitiative();
-    }
-
     private async _onSetInitiativeMode(combatant: SR5Combatant, mode: InitiativeModeOptions): Promise<void> {
         const actor = combatant.actor;
         if (!actor || !combatant.isOwner) return;
@@ -232,9 +229,9 @@ export class SR5CombatTracker extends CombatTracker {
     // Utility & DOM Helpers
     // ==========================================
 
-    /** Helper to grab a combatant reliably from any child element of a list item */
+    /** Helper to grab a combatant from any element inside a combatant entry */
     private _getCombatant(element: HTMLElement): SR5Combatant | null {
-        const combatantElement = element.closest<HTMLElement>('.combatant[data-combatant-id]');
+        const combatantElement = element.closest<HTMLElement>('[data-combatant-id]');
         const combatantId = combatantElement?.dataset.combatantId;
         if (!combatantId) return null;
 

--- a/src/module/types/global.ts
+++ b/src/module/types/global.ts
@@ -51,6 +51,7 @@ import { ComplexFormLevelType, FireModeType, FireRangeType, SpellForceType } fro
 
 import { RoutingLib } from "../integrations/routingLibIntegration";
 import SR5CompendiaSettings from "../settings/SR5CompendiaSettings";
+import { CombatTrackerDockConfig } from "../integrations/combatTrackerDockIntegration";
 import AstralPerceptionDetectionMode from "../vision/astralPerception/astralPerceptionDetectionMode";
 import AugmentedRealityVisionDetectionMode from "../vision/augmentedReality/arDetectionMode";
 import LowlightVisionDetectionMode from "../vision/lowlightVision/lowlightDetectionMode";
@@ -257,6 +258,7 @@ declare module "fvtt-types/configuration" {
             dropItemSheetData: any;
             // Hooks for Autocomplete Inline Properties integration
             aipSetup: (packageConfig: {packageName: string}[]) => void;
+            'combat-tracker-dock-init': (config: CombatTrackerDockConfig) => void;
         }
     }
 


### PR DESCRIPTION
## Summary

Adds a compatibility integration for Carousel Combat Tracker.

- Hide SR5’s internal initiative-pass pad combatants from Carousel portraits.
- Add Previous Pass and Next Pass controls and use SR5 terminology for Carousel navigation.
- Add Seize Initiative to Carousel’s combatant context menu through Foundry’s combat directory.
